### PR TITLE
Lightweight lifecycle system: Pause / Resume / Fast Restore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -589,13 +589,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
 dependencies = [
  "libc",
- "redox_users",
+ "redox_users 0.4.6",
  "winapi",
 ]
 
@@ -607,8 +616,20 @@ checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.4.6",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.5.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -618,7 +639,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
- "redox_users",
+ "redox_users 0.4.6",
  "winapi",
 ]
 
@@ -1386,8 +1407,11 @@ dependencies = [
 name = "machine"
 version = "0.0.0"
 dependencies = [
+ "dirs 6.0.0",
  "log",
  "riscv-core",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1756,6 +1780,17 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ vpod --mount workspace:/workspace:rw # read and write
 | `Sandbox.create()` | Create a new sandbox |
 | `sandbox.commands.run(cmd)` | Run a command |
 | `sandbox.code.run(code)` | Run Python code |
+| `sandbox.suspend()` | Suspend session to disk, returns instance ID |
+| `Sandbox.resume(id)` | Resume a suspended instance |
+| `Sandbox.list_instances()` | List all instances |
 
 ```python
 from vpod import Sandbox
@@ -196,6 +199,25 @@ for snap in snapshots.catalog():
 snapshots.pull("vsnap-data")
 ```
 
+
+### Suspend & Resume
+
+Pause a running sandbox and resume it later — no daemon, no background process. The VM state is serialized to disk and reconstructed on demand.
+
+```python
+from vpod import Sandbox
+
+with Sandbox.create() as sandbox:
+    sandbox.commands.run("export SECRET=42")
+    instance_id = sandbox.suspend()
+
+# Later (even from a new process):
+sandbox = Sandbox.resume(instance_id)
+result = sandbox.commands.run("echo $SECRET")
+print(result.stdout)  # 42
+```
+
+Only dirty memory pages are saved, making suspend/resume fast (~50-100ms) and storage-efficient (<1MB for short sessions).
 
 ## Limitations
 - **Emulation overhead**: No hardware acceleration in the WASM component. CPU-intensive workloads may run slower than native.

--- a/README.md
+++ b/README.md
@@ -140,9 +140,11 @@ vpod --mount workspace:/workspace:rw # read and write
 | `Sandbox.create()` | Create a new sandbox |
 | `sandbox.commands.run(cmd)` | Run a command |
 | `sandbox.code.run(code)` | Run Python code |
-| `sandbox.suspend()` | Suspend session to disk, returns session ID |
-| `Sandbox.resume(id)` | Resume a suspended session |
+| `sandbox.close()` | Shut down the running sandbox (suspended instances are unaffected) |
+| `sandbox.suspend()` | Suspend to disk, returns an instance ID |
+| `Sandbox.resume(id)` | Resume a suspended instance |
 | `Sandbox.list_instances()` | List all instances |
+| `Sandbox.destroy(id)` | Delete a suspended instance from disk |
 
 ```python
 from vpod import Sandbox
@@ -212,12 +214,15 @@ with Sandbox.create() as sandbox:
     instance_id = sandbox.suspend()
 
 # Later (even from a new process):
-sandbox = Sandbox.resume(instance_id)
-result = sandbox.commands.run("echo $SECRET")
-print(result.stdout)  # 42
+with Sandbox.resume(instance_id) as sandbox:
+    result = sandbox.commands.run("echo $SECRET")
+    print(result.stdout)  # 42
+
+# Delete the suspended instance from disk when you no longer need it
+Sandbox.destroy(instance_id)
 ```
 
-Only dirty memory pages are saved, making suspend/resume fast (~50-100ms) and storage-efficient (<1MB for short sessions).
+Only what changed is saved, so suspending is quick and the saved state stays small.
 
 ## Limitations
 - **Emulation overhead**: No hardware acceleration in the WASM component. CPU-intensive workloads may run slower than native.

--- a/README.md
+++ b/README.md
@@ -140,9 +140,9 @@ vpod --mount workspace:/workspace:rw # read and write
 | `Sandbox.create()` | Create a new sandbox |
 | `sandbox.commands.run(cmd)` | Run a command |
 | `sandbox.code.run(code)` | Run Python code |
-| `sandbox.suspend()` | Suspend session to disk, returns instance ID |
-| `Sandbox.resume(id)` | Resume a suspended instance |
-| `Sandbox.list_instances()` | List all instances |
+| `sandbox.suspend()` | Suspend session to disk, returns session ID |
+| `Sandbox.resume(id)` | Resume a suspended session |
+| `Sandbox.list_sessions()` | List all sessions |
 
 ```python
 from vpod import Sandbox

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ vpod --mount workspace:/workspace:rw # read and write
 | `sandbox.code.run(code)` | Run Python code |
 | `sandbox.suspend()` | Suspend session to disk, returns session ID |
 | `Sandbox.resume(id)` | Resume a suspended session |
-| `Sandbox.list_sessions()` | List all sessions |
+| `Sandbox.list_instances()` | List all instances |
 
 ```python
 from vpod import Sandbox

--- a/crates/machine/Cargo.toml
+++ b/crates/machine/Cargo.toml
@@ -6,3 +6,6 @@ edition = "2024"
 [dependencies]
 riscv-core = { path = "../riscv-core" }
 log = "0.4"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+dirs = "6"

--- a/crates/machine/src/cow_ram.rs
+++ b/crates/machine/src/cow_ram.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 pub const PAGE_SIZE: usize = 4096;
 
 pub struct CowRam {
-    base: Arc<[u8]>,
+    base: Arc<Vec<u8>>,
     pages: Vec<Option<Box<[u8]>>>,
     len: usize,
     mask: u64,
@@ -23,9 +23,25 @@ impl CowRam {
         base.resize(num_pages * PAGE_SIZE, 0);
 
         Self {
-            base: Arc::from(base.into_boxed_slice()),
+            base: Arc::new(base),
             pages: vec![None; num_pages],
             len,
+            mask: ram_size - 1,
+        }
+    }
+
+    pub fn padded_len(logical_len: usize) -> usize {
+        logical_len.div_ceil(PAGE_SIZE) * PAGE_SIZE
+    }
+
+    pub fn from_padded(padded: Vec<u8>, logical_len: usize, ram_size: u64) -> Self {
+        debug_assert_eq!(padded.len(), Self::padded_len(logical_len));
+        let num_pages = padded.len() / PAGE_SIZE;
+
+        Self {
+            base: Arc::new(padded),
+            pages: vec![None; num_pages],
+            len: logical_len,
             mask: ram_size - 1,
         }
     }
@@ -223,12 +239,12 @@ impl CowRam {
         Ok(())
     }
 
-    pub fn reset_base(&mut self, bytes: Vec<u8>) {
-        let num_pages = self.len.div_ceil(PAGE_SIZE);
-        let mut base = bytes;
-        base.resize(num_pages * PAGE_SIZE, 0);
 
-        self.base = Arc::from(base.into_boxed_slice());
+    pub fn set_base(&mut self, padded: Vec<u8>) {
+        debug_assert_eq!(padded.len(), Self::padded_len(self.len));
+        let num_pages = padded.len() / PAGE_SIZE;
+
+        self.base = Arc::new(padded);
         self.pages = vec![None; num_pages];
     }
 }

--- a/crates/machine/src/cow_ram.rs
+++ b/crates/machine/src/cow_ram.rs
@@ -239,7 +239,6 @@ impl CowRam {
         Ok(())
     }
 
-
     pub fn set_base(&mut self, padded: Vec<u8>) {
         debug_assert_eq!(padded.len(), Self::padded_len(self.len));
         let num_pages = padded.len() / PAGE_SIZE;

--- a/crates/machine/src/cow_ram.rs
+++ b/crates/machine/src/cow_ram.rs
@@ -1,0 +1,234 @@
+// Copy-on-write guest RAM.
+use std::sync::Arc;
+
+pub const PAGE_SIZE: usize = 4096;
+
+pub struct CowRam {
+    base: Arc<[u8]>,
+    pages: Vec<Option<Box<[u8]>>>,
+    len: usize,
+    mask: u64,
+}
+
+impl CowRam {
+    pub fn new(ram_size: u64) -> Self {
+        Self::from_base(vec![0u8; ram_size as usize + 8], ram_size)
+    }
+
+    pub fn from_base(bytes: Vec<u8>, ram_size: u64) -> Self {
+        let len = bytes.len();
+        let num_pages = len.div_ceil(PAGE_SIZE);
+
+        let mut base = bytes;
+        base.resize(num_pages * PAGE_SIZE, 0);
+
+        Self {
+            base: Arc::from(base.into_boxed_slice()),
+            pages: vec![None; num_pages],
+            len,
+            mask: ram_size - 1,
+        }
+    }
+
+    pub fn clone_shared(&self) -> Self {
+        Self {
+            base: Arc::clone(&self.base),
+            pages: vec![None; self.pages.len()],
+            len: self.len,
+            mask: self.mask,
+        }
+    }
+
+    #[inline(always)]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    #[inline(always)]
+    pub fn mask(&self) -> u64 {
+        self.mask
+    }
+
+    #[inline(always)]
+    fn page_ref(&self, page: usize) -> &[u8] {
+        match &self.pages[page] {
+            Some(p) => p,
+            None => &self.base[page * PAGE_SIZE..(page + 1) * PAGE_SIZE],
+        }
+    }
+
+    #[inline(always)]
+    fn page_mut(&mut self, page: usize) -> &mut [u8] {
+        let base = &self.base;
+
+        self.pages[page].get_or_insert_with(|| {
+            let mut owned = vec![0u8; PAGE_SIZE].into_boxed_slice();
+            owned.copy_from_slice(&base[page * PAGE_SIZE..(page + 1) * PAGE_SIZE]);
+
+            owned
+        })
+    }
+
+    #[inline(always)]
+    pub fn read_u8(&self, idx: usize) -> u8 {
+        self.page_ref(idx >> 12)[idx & (PAGE_SIZE - 1)]
+    }
+
+    #[inline(always)]
+    pub fn write_u8(&mut self, idx: usize, val: u8) {
+        self.page_mut(idx >> 12)[idx & (PAGE_SIZE - 1)] = val;
+    }
+
+    #[inline(always)]
+    pub fn read_u16(&self, idx: usize) -> u16 {
+        let off = idx & (PAGE_SIZE - 1);
+
+        if off + 2 <= PAGE_SIZE {
+            let p = self.page_ref(idx >> 12);
+
+            u16::from_le_bytes([p[off], p[off + 1]])
+        } else {
+            u16::from_le_bytes([self.read_u8(idx), self.read_u8(idx + 1)])
+        }
+    }
+
+    #[inline(always)]
+    pub fn read_u32(&self, idx: usize) -> u32 {
+        let off = idx & (PAGE_SIZE - 1);
+
+        if off + 4 <= PAGE_SIZE {
+            let p = self.page_ref(idx >> 12);
+
+            u32::from_le_bytes(p[off..off + 4].try_into().unwrap())
+        } else {
+            let mut b = [0u8; 4];
+
+            self.read_into(idx, &mut b);
+            u32::from_le_bytes(b)
+        }
+    }
+
+    #[inline(always)]
+    pub fn read_u64(&self, idx: usize) -> u64 {
+        let off = idx & (PAGE_SIZE - 1);
+
+        if off + 8 <= PAGE_SIZE {
+            let p = self.page_ref(idx >> 12);
+
+            u64::from_le_bytes(p[off..off + 8].try_into().unwrap())
+        } else {
+            let mut b = [0u8; 8];
+
+            self.read_into(idx, &mut b);
+            u64::from_le_bytes(b)
+        }
+    }
+
+    #[inline(always)]
+    pub fn write_u16(&mut self, idx: usize, val: u16) {
+        let off = idx & (PAGE_SIZE - 1);
+
+        if off + 2 <= PAGE_SIZE {
+            self.page_mut(idx >> 12)[off..off + 2].copy_from_slice(&val.to_le_bytes());
+        } else {
+            self.write_from(idx, &val.to_le_bytes());
+        }
+    }
+
+    #[inline(always)]
+    pub fn write_u32(&mut self, idx: usize, val: u32) {
+        let off = idx & (PAGE_SIZE - 1);
+
+        if off + 4 <= PAGE_SIZE {
+            self.page_mut(idx >> 12)[off..off + 4].copy_from_slice(&val.to_le_bytes());
+        } else {
+            self.write_from(idx, &val.to_le_bytes());
+        }
+    }
+
+    #[inline(always)]
+    pub fn write_u64(&mut self, idx: usize, val: u64) {
+        let off = idx & (PAGE_SIZE - 1);
+
+        if off + 8 <= PAGE_SIZE {
+            self.page_mut(idx >> 12)[off..off + 8].copy_from_slice(&val.to_le_bytes());
+        } else {
+            self.write_from(idx, &val.to_le_bytes());
+        }
+    }
+
+    pub fn read_into(&self, mut idx: usize, buf: &mut [u8]) {
+        let mut written = 0;
+
+        while written < buf.len() {
+            let page = idx >> 12;
+            let off = idx & (PAGE_SIZE - 1);
+            let n = (PAGE_SIZE - off).min(buf.len() - written);
+
+            buf[written..written + n].copy_from_slice(&self.page_ref(page)[off..off + n]);
+            written += n;
+            idx += n;
+        }
+    }
+
+    pub fn write_from(&mut self, mut idx: usize, buf: &[u8]) {
+        let mut read = 0;
+
+        while read < buf.len() {
+            let page = idx >> 12;
+            let off = idx & (PAGE_SIZE - 1);
+            let n = (PAGE_SIZE - off).min(buf.len() - read);
+
+            self.page_mut(page)[off..off + n].copy_from_slice(&buf[read..read + n]);
+            read += n;
+            idx += n;
+        }
+    }
+
+    pub fn dirty_pages(&self) -> Vec<u32> {
+        self.pages
+            .iter()
+            .enumerate()
+            .filter_map(|(i, p)| p.as_ref().map(|_| i as u32))
+            .collect()
+    }
+
+    pub fn page_bytes(&self, page: usize) -> &[u8] {
+        self.page_ref(page)
+    }
+
+    pub fn apply_page(&mut self, page: usize, bytes: &[u8; PAGE_SIZE]) {
+        self.page_mut(page).copy_from_slice(bytes);
+    }
+
+    pub fn num_pages(&self) -> usize {
+        self.pages.len()
+    }
+
+    pub fn write_all_to(&self, writer: &mut impl std::io::Write) -> std::io::Result<()> {
+        let mut remaining = self.len;
+        let mut page = 0;
+
+        while remaining > 0 {
+            let n = remaining.min(PAGE_SIZE);
+            writer.write_all(&self.page_ref(page)[..n])?;
+            remaining -= n;
+            page += 1;
+        }
+        Ok(())
+    }
+
+    pub fn reset_base(&mut self, bytes: Vec<u8>) {
+        let num_pages = self.len.div_ceil(PAGE_SIZE);
+        let mut base = bytes;
+        base.resize(num_pages * PAGE_SIZE, 0);
+
+        self.base = Arc::from(base.into_boxed_slice());
+        self.pages = vec![None; num_pages];
+    }
+}

--- a/crates/machine/src/instance.rs
+++ b/crates/machine/src/instance.rs
@@ -1,0 +1,132 @@
+use std::fs;
+use std::io;
+use std::path::PathBuf;
+
+use riscv_core::Hart;
+
+use crate::machine_bus::MachineBus;
+use crate::snapshot;
+
+const COLLAPSE_THRESHOLD: f64 = 0.25;
+
+pub fn instances_dir() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".vpod")
+        .join("instances")
+}
+
+pub fn instance_dir(instance_id: &str) -> PathBuf {
+    instances_dir().join(instance_id)
+}
+
+pub fn suspend(bus: &MachineBus, hart: &Hart, instance_id: &str) -> io::Result<()> {
+    let dir = instance_dir(instance_id);
+    fs::create_dir_all(&dir)?;
+
+    let mut delta_buf = Vec::new();
+    snapshot::save_delta(bus, hart, &mut delta_buf)?;
+    fs::write(dir.join("delta.bin"), &delta_buf)?;
+
+    update_manifest(instance_id, "SUSPENDED")?;
+    Ok(())
+}
+
+pub fn resume(bus: &mut MachineBus, hart: &mut Hart, instance_id: &str) -> io::Result<()> {
+    let dir = instance_dir(instance_id);
+    let delta_bytes = fs::read(dir.join("delta.bin"))?;
+
+    let mut cursor = io::Cursor::new(&delta_bytes);
+    snapshot::restore_delta(bus, hart, &mut cursor)?;
+
+    update_manifest(instance_id, "RUNNING")?;
+    Ok(())
+}
+
+pub fn should_collapse(bus: &MachineBus) -> bool {
+    let dirty_count = bus.dirty_pages().len();
+    let total_pages = (bus.ram_size() >> 12) as usize;
+    dirty_count as f64 / total_pages as f64 > COLLAPSE_THRESHOLD
+}
+
+pub fn collapse(bus: &MachineBus, hart: &Hart, instance_id: &str, flags: u8) -> io::Result<()> {
+    let dir = instance_dir(instance_id);
+    let base_path = dir.join("base.vpod");
+
+    let mut buf = Vec::new();
+    snapshot::save(bus, hart, &mut buf, flags)?;
+    fs::write(&base_path, &buf)?;
+
+    let delta_path = dir.join("delta.bin");
+    if delta_path.exists() {
+        fs::remove_file(&delta_path)?;
+    }
+
+    Ok(())
+}
+
+pub fn destroy(instance_id: &str) -> io::Result<()> {
+    let dir = instance_dir(instance_id);
+    if dir.exists() {
+        fs::remove_dir_all(&dir)?;
+    }
+    remove_from_manifest(instance_id)?;
+    Ok(())
+}
+
+pub fn list() -> io::Result<Vec<ManifestEntry>> {
+    let manifest_path = instances_dir().join("manifest.json");
+    if !manifest_path.exists() {
+        return Ok(Vec::new());
+    }
+    let data = fs::read_to_string(&manifest_path)?;
+    let entries: Vec<ManifestEntry> = serde_json::from_str(&data).unwrap_or_default();
+    Ok(entries)
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ManifestEntry {
+    pub id: String,
+    pub state: String,
+}
+
+fn read_manifest() -> Vec<ManifestEntry> {
+    let path = instances_dir().join("manifest.json");
+
+    if !path.exists() {
+        return Vec::new();
+    }
+
+    fs::read_to_string(&path)
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default()
+}
+
+fn write_manifest(entries: &[ManifestEntry]) -> io::Result<()> {
+    let dir = instances_dir();
+    fs::create_dir_all(&dir)?;
+
+    let path = dir.join("manifest.json");
+    let json = serde_json::to_string_pretty(entries).map_err(io::Error::other)?;
+
+    fs::write(&path, json)
+}
+
+fn update_manifest(instance_id: &str, state: &str) -> io::Result<()> {
+    let mut entries = read_manifest();
+
+    entries.retain(|e| e.id != instance_id);
+    entries.push(ManifestEntry {
+        id: instance_id.to_string(),
+        state: state.to_string(),
+    });
+
+    write_manifest(&entries)
+}
+
+fn remove_from_manifest(instance_id: &str) -> io::Result<()> {
+    let mut entries = read_manifest();
+    entries.retain(|e| e.id != instance_id);
+    write_manifest(&entries)
+}

--- a/crates/machine/src/lib.rs
+++ b/crates/machine/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod clint;
+pub mod cow_ram;
 pub mod dtb;
+pub mod instance;
 pub mod machine_bus;
 pub mod plic;
 pub mod snapshot;

--- a/crates/machine/src/machine_bus.rs
+++ b/crates/machine/src/machine_bus.rs
@@ -24,6 +24,7 @@ use riscv_core::{Hart, SystemBus};
 pub struct MachineBus {
     pub ram: Vec<u8>,
     ram_mask: u64,
+    pub dirty_bitmap: Vec<u64>,
     pub low_ram: Vec<u8>,
     pub uart: Uart,
     pub uart_stderr: Uart,
@@ -43,9 +44,13 @@ impl MachineBus {
             ram_size.is_power_of_two(),
             "ram_size must be a power of two"
         );
+        let num_pages = (ram_size >> 12) as usize;
+        let bitmap_len = num_pages.div_ceil(64);
+
         Self {
             ram: vec![0u8; ram_size as usize + 8],
             ram_mask: ram_size - 1,
+            dirty_bitmap: vec![0u64; bitmap_len],
             low_ram: vec![0u8; LOW_RAM_SIZE as usize],
             uart: Uart::new(),
             uart_stderr: Uart::new(),
@@ -94,9 +99,38 @@ impl MachineBus {
         self.ram.len() as u64
     }
 
+    pub fn dirty_pages(&self) -> Vec<u32> {
+        let mut pages = Vec::new();
+
+        for (i, &word) in self.dirty_bitmap.iter().enumerate() {
+            if word == 0 {
+                continue;
+            }
+
+            let mut w = word;
+            while w != 0 {
+                let bit = w.trailing_zeros() as usize;
+                pages.push((i * 64 + bit) as u32);
+                w &= w - 1;
+            }
+        }
+
+        pages
+    }
+
+    pub fn clear_dirty_bitmap(&mut self) {
+        self.dirty_bitmap.fill(0);
+    }
+
     pub fn load_ram(&mut self, offset: u64, data: &[u8]) {
         let start = offset as usize;
         self.ram[start..start + data.len()].copy_from_slice(data);
+        let first_page = start >> 12;
+        let last_page = (start + data.len()).saturating_sub(1) >> 12;
+
+        for page in first_page..=last_page {
+            self.dirty_bitmap[page / 64] |= 1 << (page % 64);
+        }
     }
 
     pub fn load_low_ram(&mut self, offset: u64, data: &[u8]) {
@@ -140,7 +174,7 @@ impl MachineBus {
 
         if let Some(network_device) = &mut self.net {
             let mask = self.ram_mask;
-            let mut ram = RamView::new(&mut self.ram, mask);
+            let mut ram = RamView::with_dirty_bitmap(&mut self.ram, mask, &mut self.dirty_bitmap);
             network_device.poll_rx(&mut ram);
             self.plic
                 .set_irq(VIRTIO_NET_IRQ, network_device.mmio.int_status != 0);
@@ -187,7 +221,7 @@ impl MachineBus {
 
     pub fn flush_console_rx(&mut self) {
         let mask = self.ram_mask;
-        let mut ram = RamView::new(&mut self.ram, mask);
+        let mut ram = RamView::with_dirty_bitmap(&mut self.ram, mask, &mut self.dirty_bitmap);
         self.console.flush_rx(&mut ram);
     }
 
@@ -197,8 +231,20 @@ impl MachineBus {
     }
 
     #[inline(always)]
+    fn mark_page_dirty(&mut self, ram_offset: usize) {
+        let page = ram_offset >> 12;
+
+        unsafe {
+            let word = self.dirty_bitmap.get_unchecked_mut(page / 64);
+            *word |= 1 << (page % 64);
+        }
+    }
+
+    #[inline(always)]
     fn ram_write_u8(&mut self, physical_address: u64, value: u8) {
         let index = self.ram_index(physical_address);
+
+        self.mark_page_dirty(index);
         unsafe {
             *self.ram.get_unchecked_mut(index) = value;
         }
@@ -384,9 +430,12 @@ impl SystemBus for MachineBus {
 
         if address >= RAM_BASE && address + 3 < RAM_BASE + self.ram.len() as u64 {
             let index = (address - RAM_BASE) as usize;
+            self.mark_page_dirty(index);
+
             unsafe {
                 *(self.ram.as_mut_ptr().add(index) as *mut [u8; 4]) = value.to_le_bytes();
             }
+
             return;
         }
 
@@ -421,7 +470,8 @@ impl SystemBus for MachineBus {
 
             if let Some(queue_index) = notify_queue_index {
                 let mask = self.ram_mask;
-                let mut ram = RamView::new(&mut self.ram, mask);
+                let mut ram =
+                    RamView::with_dirty_bitmap(&mut self.ram, mask, &mut self.dirty_bitmap);
 
                 match slot {
                     0 => {
@@ -456,6 +506,8 @@ impl SystemBus for MachineBus {
     fn write_doubleword(&mut self, address: u64, value: u64) {
         if address >= RAM_BASE && address + 7 < RAM_BASE + self.ram.len() as u64 {
             let index = (address - RAM_BASE) as usize;
+
+            self.mark_page_dirty(index);
             unsafe {
                 *(self.ram.as_mut_ptr().add(index) as *mut [u8; 8]) = value.to_le_bytes();
             }

--- a/crates/machine/src/machine_bus.rs
+++ b/crates/machine/src/machine_bus.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use crate::clint::{CLINT_BASE, CLINT_SIZE, Clint, TIMER_FREQUENCY};
+use crate::cow_ram::CowRam;
 use crate::dtb;
 use crate::plic::{PLIC_BASE, PLIC_SIZE, Plic};
 use crate::uart::Uart;
@@ -22,9 +23,8 @@ use riscv_core::csr::{MIP_MEIP, MIP_MSIP, MIP_MTIP, MIP_SEIP};
 use riscv_core::{Hart, SystemBus};
 
 pub struct MachineBus {
-    pub ram: Vec<u8>,
+    pub ram: CowRam,
     ram_mask: u64,
-    pub dirty_bitmap: Vec<u64>,
     pub low_ram: Vec<u8>,
     pub uart: Uart,
     pub uart_stderr: Uart,
@@ -39,18 +39,15 @@ pub struct MachineBus {
 }
 
 impl MachineBus {
-    pub fn new(ram_size: u64) -> Self {
+    pub fn new(ram_size: u64, ram: CowRam) -> Self {
         assert!(
             ram_size.is_power_of_two(),
             "ram_size must be a power of two"
         );
-        let num_pages = (ram_size >> 12) as usize;
-        let bitmap_len = num_pages.div_ceil(64);
 
         Self {
-            ram: vec![0u8; ram_size as usize + 8],
+            ram,
             ram_mask: ram_size - 1,
-            dirty_bitmap: vec![0u64; bitmap_len],
             low_ram: vec![0u8; LOW_RAM_SIZE as usize],
             uart: Uart::new(),
             uart_stderr: Uart::new(),
@@ -100,37 +97,11 @@ impl MachineBus {
     }
 
     pub fn dirty_pages(&self) -> Vec<u32> {
-        let mut pages = Vec::new();
-
-        for (i, &word) in self.dirty_bitmap.iter().enumerate() {
-            if word == 0 {
-                continue;
-            }
-
-            let mut w = word;
-            while w != 0 {
-                let bit = w.trailing_zeros() as usize;
-                pages.push((i * 64 + bit) as u32);
-                w &= w - 1;
-            }
-        }
-
-        pages
-    }
-
-    pub fn clear_dirty_bitmap(&mut self) {
-        self.dirty_bitmap.fill(0);
+        self.ram.dirty_pages()
     }
 
     pub fn load_ram(&mut self, offset: u64, data: &[u8]) {
-        let start = offset as usize;
-        self.ram[start..start + data.len()].copy_from_slice(data);
-        let first_page = start >> 12;
-        let last_page = (start + data.len()).saturating_sub(1) >> 12;
-
-        for page in first_page..=last_page {
-            self.dirty_bitmap[page / 64] |= 1 << (page % 64);
-        }
+        self.ram.write_from(offset as usize, data);
     }
 
     pub fn load_low_ram(&mut self, offset: u64, data: &[u8]) {
@@ -174,8 +145,10 @@ impl MachineBus {
 
         if let Some(network_device) = &mut self.net {
             let mask = self.ram_mask;
-            let mut ram = RamView::with_dirty_bitmap(&mut self.ram, mask, &mut self.dirty_bitmap);
+            let mut ram = RamView::new(&mut self.ram, mask);
+
             network_device.poll_rx(&mut ram);
+
             self.plic
                 .set_irq(VIRTIO_NET_IRQ, network_device.mmio.int_status != 0);
         }
@@ -221,7 +194,8 @@ impl MachineBus {
 
     pub fn flush_console_rx(&mut self) {
         let mask = self.ram_mask;
-        let mut ram = RamView::with_dirty_bitmap(&mut self.ram, mask, &mut self.dirty_bitmap);
+        let mut ram = RamView::new(&mut self.ram, mask);
+
         self.console.flush_rx(&mut ram);
     }
 
@@ -231,34 +205,20 @@ impl MachineBus {
     }
 
     #[inline(always)]
-    fn mark_page_dirty(&mut self, ram_offset: usize) {
-        let page = ram_offset >> 12;
-
-        unsafe {
-            let word = self.dirty_bitmap.get_unchecked_mut(page / 64);
-            *word |= 1 << (page % 64);
-        }
-    }
-
-    #[inline(always)]
     fn ram_write_u8(&mut self, physical_address: u64, value: u8) {
         let index = self.ram_index(physical_address);
-
-        self.mark_page_dirty(index);
-        unsafe {
-            *self.ram.get_unchecked_mut(index) = value;
-        }
+        self.ram.write_u8(index, value);
     }
 
     #[inline(always)]
     fn ram_read_u8(&self, physical_address: u64) -> u8 {
         let index = self.ram_index(physical_address);
-
-        unsafe { *self.ram.get_unchecked(index) }
+        self.ram.read_u8(index)
     }
 
     fn virtio_device_slot(&self, address: u64) -> Option<usize> {
         let num_slots = 3 + VIRTIO_MAX_FS;
+
         if (VIRTIO_BASE..VIRTIO_BASE + VIRTIO_SIZE * num_slots as u64).contains(&address) {
             Some(((address - VIRTIO_BASE) / VIRTIO_SIZE) as usize)
         } else {
@@ -331,9 +291,8 @@ impl SystemBus for MachineBus {
     fn read_word(&mut self, address: u64) -> u32 {
         if address >= RAM_BASE && address + 3 < RAM_BASE + self.ram.len() as u64 {
             let index = (address - RAM_BASE) as usize;
-            return unsafe {
-                u32::from_le_bytes(*(self.ram.as_ptr().add(index) as *const [u8; 4]))
-            };
+
+            return self.ram.read_u32(index);
         }
 
         if (CLINT_BASE..CLINT_BASE + CLINT_SIZE - 3).contains(&address) {
@@ -375,9 +334,8 @@ impl SystemBus for MachineBus {
     fn read_doubleword(&mut self, address: u64) -> u64 {
         if address >= RAM_BASE && address + 7 < RAM_BASE + self.ram.len() as u64 {
             let index = (address - RAM_BASE) as usize;
-            return unsafe {
-                u64::from_le_bytes(*(self.ram.as_ptr().add(index) as *const [u8; 8]))
-            };
+
+            return self.ram.read_u64(index);
         }
 
         (self.read_word(address) as u64) | ((self.read_word(address + 4) as u64) << 32)
@@ -430,12 +388,8 @@ impl SystemBus for MachineBus {
 
         if address >= RAM_BASE && address + 3 < RAM_BASE + self.ram.len() as u64 {
             let index = (address - RAM_BASE) as usize;
-            self.mark_page_dirty(index);
 
-            unsafe {
-                *(self.ram.as_mut_ptr().add(index) as *mut [u8; 4]) = value.to_le_bytes();
-            }
-
+            self.ram.write_u32(index, value);
             return;
         }
 
@@ -470,8 +424,7 @@ impl SystemBus for MachineBus {
 
             if let Some(queue_index) = notify_queue_index {
                 let mask = self.ram_mask;
-                let mut ram =
-                    RamView::with_dirty_bitmap(&mut self.ram, mask, &mut self.dirty_bitmap);
+                let mut ram = RamView::new(&mut self.ram, mask);
 
                 match slot {
                     0 => {
@@ -506,11 +459,7 @@ impl SystemBus for MachineBus {
     fn write_doubleword(&mut self, address: u64, value: u64) {
         if address >= RAM_BASE && address + 7 < RAM_BASE + self.ram.len() as u64 {
             let index = (address - RAM_BASE) as usize;
-
-            self.mark_page_dirty(index);
-            unsafe {
-                *(self.ram.as_mut_ptr().add(index) as *mut [u8; 8]) = value.to_le_bytes();
-            }
+            self.ram.write_u64(index, value);
             return;
         }
 
@@ -624,11 +573,7 @@ pub fn boot(
 
     let _ = std::fs::write("/tmp/vpod.dtb", &dtb_data);
 
-    let dtb_magic = u32::from_le_bytes(
-        bus.ram[dtb_offset as usize..dtb_offset as usize + 4]
-            .try_into()
-            .unwrap(),
-    );
+    let dtb_magic = bus.ram.read_u32(dtb_offset as usize);
 
     eprintln!(
         "[boot] entry={:#x} kernel={:#x}+{:#x} initrd={:#x}..{:#x} dtb={:#x} dtb_magic={:#010x}({}) dtb_size={}",

--- a/crates/machine/src/snapshot.rs
+++ b/crates/machine/src/snapshot.rs
@@ -14,6 +14,7 @@ pub const FLAG_SHELL_READY: u8 = 1 << 0;
 pub const FLAG_PYTHON_READY: u8 = 1 << 1;
 
 const DELTA_MAGIC: &[u8; 4] = b"VDLT";
+const DELTA_VERSION: u8 = 1;
 const PAGE_SIZE: usize = 4096;
 
 pub fn save(
@@ -29,7 +30,7 @@ pub fn save(
 
     let ram_size = bus.ram_size();
     writer.write_all(&ram_size.to_le_bytes())?;
-    writer.write_all(&bus.ram)?;
+    bus.ram.write_all_to(writer)?;
     writer.write_all(&bus.low_ram)?;
 
     save_hart(hart, writer)?;
@@ -100,7 +101,9 @@ pub fn restore(bus: &mut MachineBus, hart: &mut Hart, reader: &mut impl Read) ->
         ));
     }
 
-    reader.read_exact(&mut bus.ram)?;
+    let mut ram_bytes = vec![0u8; ram_size as usize];
+    reader.read_exact(&mut ram_bytes)?;
+    bus.ram.reset_base(ram_bytes);
 
     let mut low = vec![0u8; LOW_RAM_SIZE as usize];
     reader.read_exact(&mut low)?;
@@ -144,8 +147,33 @@ pub fn restore(bus: &mut MachineBus, hart: &mut Hart, reader: &mut impl Read) ->
     Ok(flags[0])
 }
 
+pub fn base_ram(bytes: &[u8]) -> io::Result<(Vec<u8>, u64)> {
+    const HEADER: usize = 4 + 1 + 1 + 8;
+
+    if bytes.len() < HEADER || &bytes[0..4] != MAGIC {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid snapshot magic",
+        ));
+    }
+
+    let ram_field = u64::from_le_bytes(bytes[6..14].try_into().unwrap()) as usize;
+    let end = HEADER + ram_field;
+
+    if bytes.len() < end {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "snapshot truncated before end of RAM",
+        ));
+    }
+
+    let real_size = (ram_field - 8) as u64;
+    Ok((bytes[HEADER..end].to_vec(), real_size))
+}
+
 pub fn save_delta(bus: &MachineBus, hart: &Hart, writer: &mut impl Write) -> io::Result<()> {
     writer.write_all(DELTA_MAGIC)?;
+    writer.write_all(&[DELTA_VERSION])?;
 
     let dirty_pages = bus.dirty_pages();
     let page_count = dirty_pages.len() as u32;
@@ -153,8 +181,7 @@ pub fn save_delta(bus: &MachineBus, hart: &Hart, writer: &mut impl Write) -> io:
 
     for &page_idx in &dirty_pages {
         writer.write_all(&page_idx.to_le_bytes())?;
-        let offset = page_idx as usize * PAGE_SIZE;
-        writer.write_all(&bus.ram[offset..offset + PAGE_SIZE])?;
+        writer.write_all(bus.ram.page_bytes(page_idx as usize))?;
     }
 
     writer.write_all(&bus.low_ram)?;
@@ -201,6 +228,18 @@ pub fn restore_delta(
         ));
     }
 
+    let mut version = [0u8; 1];
+    reader.read_exact(&mut version)?;
+    if version[0] != DELTA_VERSION {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "unsupported delta version {} (expected {})",
+                version[0], DELTA_VERSION
+            ),
+        ));
+    }
+
     let mut buf4 = [0u8; 4];
     reader.read_exact(&mut buf4)?;
     let page_count = u32::from_le_bytes(buf4) as usize;
@@ -210,8 +249,7 @@ pub fn restore_delta(
         reader.read_exact(&mut buf4)?;
         let page_idx = u32::from_le_bytes(buf4) as usize;
         reader.read_exact(&mut page_buf)?;
-        let offset = page_idx * PAGE_SIZE;
-        bus.ram[offset..offset + PAGE_SIZE].copy_from_slice(&page_buf);
+        bus.ram.apply_page(page_idx, &page_buf);
     }
 
     let mut low = vec![0u8; LOW_RAM_SIZE as usize];
@@ -251,8 +289,6 @@ pub fn restore_delta(
     let _ = bus.uart_stderr.deserialize(reader);
     let _ = bus.uart_ctrl.deserialize(reader);
     let _ = bus.uart_data.deserialize(reader);
-
-    bus.clear_dirty_bitmap();
 
     Ok(())
 }

--- a/crates/machine/src/snapshot.rs
+++ b/crates/machine/src/snapshot.rs
@@ -101,10 +101,20 @@ pub fn restore(bus: &mut MachineBus, hart: &mut Hart, reader: &mut impl Read) ->
         ));
     }
 
-    let mut ram_bytes = vec![0u8; ram_size as usize];
-    reader.read_exact(&mut ram_bytes)?;
-    bus.ram.reset_base(ram_bytes);
+    let mut ram_bytes = vec![0u8; crate::cow_ram::CowRam::padded_len(ram_size as usize)];
+    reader.read_exact(&mut ram_bytes[..ram_size as usize])?;
+    bus.ram.set_base(ram_bytes);
 
+    restore_devices(bus, hart, reader)?;
+
+    Ok(flags[0])
+}
+
+pub fn restore_devices(
+    bus: &mut MachineBus,
+    hart: &mut Hart,
+    reader: &mut impl Read,
+) -> io::Result<()> {
     let mut low = vec![0u8; LOW_RAM_SIZE as usize];
     reader.read_exact(&mut low)?;
     bus.low_ram = low;
@@ -144,31 +154,51 @@ pub fn restore(bus: &mut MachineBus, hart: &mut Hart, reader: &mut impl Read) ->
     let _ = bus.uart_ctrl.deserialize(reader);
     let _ = bus.uart_data.deserialize(reader);
 
-    Ok(flags[0])
+    Ok(())
 }
 
-pub fn base_ram(bytes: &[u8]) -> io::Result<(Vec<u8>, u64)> {
-    const HEADER: usize = 4 + 1 + 1 + 8;
+pub fn load_base_and_tail(
+    reader: &mut impl Read,
+) -> io::Result<(crate::cow_ram::CowRam, Vec<u8>, u8)> {
+    let mut magic = [0u8; 4];
+    reader.read_exact(&mut magic)?;
 
-    if bytes.len() < HEADER || &bytes[0..4] != MAGIC {
+    if &magic != MAGIC {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             "invalid snapshot magic",
         ));
     }
 
-    let ram_field = u64::from_le_bytes(bytes[6..14].try_into().unwrap()) as usize;
-    let end = HEADER + ram_field;
-
-    if bytes.len() < end {
+    let mut version = [0u8; 1];
+    reader.read_exact(&mut version)?;
+    if version[0] != VERSION {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
-            "snapshot truncated before end of RAM",
+            format!(
+                "unsupported snapshot version {} (expected {})",
+                version[0], VERSION
+            ),
         ));
     }
 
-    let real_size = (ram_field - 8) as u64;
-    Ok((bytes[HEADER..end].to_vec(), real_size))
+    let mut flags = [0u8; 1];
+    reader.read_exact(&mut flags)?;
+
+    let mut ram_size_buf = [0u8; 8];
+    reader.read_exact(&mut ram_size_buf)?;
+
+    let logical_len = u64::from_le_bytes(ram_size_buf) as usize;
+    let real_size = (logical_len - 8) as u64;
+
+    let mut base = vec![0u8; crate::cow_ram::CowRam::padded_len(logical_len)];
+    reader.read_exact(&mut base[..logical_len])?;
+    let cow = crate::cow_ram::CowRam::from_padded(base, logical_len, real_size);
+
+    let mut tail = Vec::new();
+    reader.read_to_end(&mut tail)?;
+
+    Ok((cow, tail, flags[0]))
 }
 
 pub fn save_delta(bus: &MachineBus, hart: &Hart, writer: &mut impl Write) -> io::Result<()> {

--- a/crates/machine/src/snapshot.rs
+++ b/crates/machine/src/snapshot.rs
@@ -13,6 +13,9 @@ const VERSION: u8 = 1;
 pub const FLAG_SHELL_READY: u8 = 1 << 0;
 pub const FLAG_PYTHON_READY: u8 = 1 << 1;
 
+const DELTA_MAGIC: &[u8; 4] = b"VDLT";
+const PAGE_SIZE: usize = 4096;
+
 pub fn save(
     bus: &MachineBus,
     hart: &Hart,
@@ -139,6 +142,119 @@ pub fn restore(bus: &mut MachineBus, hart: &mut Hart, reader: &mut impl Read) ->
     let _ = bus.uart_data.deserialize(reader);
 
     Ok(flags[0])
+}
+
+pub fn save_delta(bus: &MachineBus, hart: &Hart, writer: &mut impl Write) -> io::Result<()> {
+    writer.write_all(DELTA_MAGIC)?;
+
+    let dirty_pages = bus.dirty_pages();
+    let page_count = dirty_pages.len() as u32;
+    writer.write_all(&page_count.to_le_bytes())?;
+
+    for &page_idx in &dirty_pages {
+        writer.write_all(&page_idx.to_le_bytes())?;
+        let offset = page_idx as usize * PAGE_SIZE;
+        writer.write_all(&bus.ram[offset..offset + PAGE_SIZE])?;
+    }
+
+    writer.write_all(&bus.low_ram)?;
+    save_hart(hart, writer)?;
+
+    bus.clint.serialize(writer)?;
+    bus.plic.save_state(writer)?;
+    bus.uart.serialize(writer)?;
+
+    bus.console.mmio.serialize(writer)?;
+
+    let has_net = bus.net.is_some();
+    writer.write_all(&[has_net as u8])?;
+
+    if let Some(net) = &bus.net {
+        net.mmio.serialize(writer)?;
+    }
+
+    let num_fs = bus.fs_devices.len() as u8;
+    writer.write_all(&[num_fs])?;
+    for fs in &bus.fs_devices {
+        fs.mmio.serialize(writer)?;
+    }
+
+    bus.uart_stderr.serialize(writer)?;
+    bus.uart_ctrl.serialize(writer)?;
+    bus.uart_data.serialize(writer)?;
+
+    Ok(())
+}
+
+pub fn restore_delta(
+    bus: &mut MachineBus,
+    hart: &mut Hart,
+    reader: &mut impl Read,
+) -> io::Result<()> {
+    let mut magic = [0u8; 4];
+    reader.read_exact(&mut magic)?;
+
+    if &magic != DELTA_MAGIC {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid delta magic",
+        ));
+    }
+
+    let mut buf4 = [0u8; 4];
+    reader.read_exact(&mut buf4)?;
+    let page_count = u32::from_le_bytes(buf4) as usize;
+
+    let mut page_buf = [0u8; PAGE_SIZE];
+    for _ in 0..page_count {
+        reader.read_exact(&mut buf4)?;
+        let page_idx = u32::from_le_bytes(buf4) as usize;
+        reader.read_exact(&mut page_buf)?;
+        let offset = page_idx * PAGE_SIZE;
+        bus.ram[offset..offset + PAGE_SIZE].copy_from_slice(&page_buf);
+    }
+
+    let mut low = vec![0u8; LOW_RAM_SIZE as usize];
+    reader.read_exact(&mut low)?;
+    bus.low_ram = low;
+
+    restore_hart(hart, reader)?;
+    bus.clint.deserialize(reader)?;
+    bus.plic.restore_state(reader)?;
+    bus.uart.deserialize(reader)?;
+    bus.console.mmio.deserialize(reader)?;
+
+    let mut has_net = [0u8; 1];
+    reader.read_exact(&mut has_net)?;
+    if has_net[0] != 0 {
+        if let Some(net) = &mut bus.net {
+            net.mmio.deserialize(reader)?;
+        } else {
+            let mut skip = VirtioMmio::new(0, 0, 2);
+            skip.deserialize(reader)?;
+        }
+    }
+
+    let mut num_fs_buf = [0u8; 1];
+    if reader.read_exact(&mut num_fs_buf).is_ok() {
+        let num_fs = num_fs_buf[0] as usize;
+        for i in 0..num_fs {
+            if let Some(fs) = bus.fs_devices.get_mut(i) {
+                fs.mmio.deserialize(reader)?;
+            } else {
+                let mut skip = VirtioMmio::new(0, 0, 2);
+                skip.deserialize(reader)?;
+            }
+        }
+    }
+
+    let _ = bus.uart_stderr.deserialize(reader);
+    let _ = bus.uart_ctrl.deserialize(reader);
+    let _ = bus.uart_data.deserialize(reader);
+
+    bus.clear_dirty_bitmap();
+
+    Ok(())
 }
 
 fn save_hart(hart: &Hart, writer: &mut impl Write) -> io::Result<()> {

--- a/crates/machine/src/virtio/blk.rs
+++ b/crates/machine/src/virtio/blk.rs
@@ -1,6 +1,6 @@
 use std::io::{Read, Seek, SeekFrom, Write};
 
-use super::{RAM_BASE, RamView, VRING_DESC_F_NEXT, VRING_DESC_F_WRITE, VirtioMmio};
+use super::{RamView, VRING_DESC_F_NEXT, VRING_DESC_F_WRITE, VirtioMmio};
 
 const DEVICE_ID: u32 = 2;
 const VIRTIO_F_VERSION_1: u64 = 1u64 << 32;
@@ -149,9 +149,9 @@ impl VirtioBlk {
 
         self.file.seek(SeekFrom::Start(sector * SECTOR_SIZE))?;
 
-        let index = ((destination - RAM_BASE) & ram.mask) as usize;
-        self.file
-            .read_exact(&mut ram.ram[index..index + length as usize])?;
+        let mut buf = vec![0u8; length as usize];
+        self.file.read_exact(&mut buf)?;
+        ram.write_bytes(destination, &buf);
 
         Ok(())
     }
@@ -170,9 +170,9 @@ impl VirtioBlk {
 
         self.file.seek(SeekFrom::Start(sector * SECTOR_SIZE))?;
 
-        let index = ((source - RAM_BASE) & ram.mask) as usize;
-        self.file
-            .write_all(&ram.ram[index..index + length as usize])?;
+        let mut buf = vec![0u8; length as usize];
+        ram.read_bytes(source, &mut buf);
+        self.file.write_all(&buf)?;
 
         Ok(())
     }

--- a/crates/machine/src/virtio/mod.rs
+++ b/crates/machine/src/virtio/mod.rs
@@ -43,11 +43,36 @@ pub const VRING_DESC_F_WRITE: u16 = 2;
 pub struct RamView<'a> {
     ram: &'a mut Vec<u8>,
     mask: u64,
+    dirty_bitmap: Option<&'a mut Vec<u64>>,
 }
 
 impl<'a> RamView<'a> {
     pub fn new(ram: &'a mut Vec<u8>, mask: u64) -> Self {
-        Self { ram, mask }
+        Self {
+            ram,
+            mask,
+            dirty_bitmap: None,
+        }
+    }
+
+    pub fn with_dirty_bitmap(
+        ram: &'a mut Vec<u8>,
+        mask: u64,
+        dirty_bitmap: &'a mut Vec<u64>,
+    ) -> Self {
+        Self {
+            ram,
+            mask,
+            dirty_bitmap: Some(dirty_bitmap),
+        }
+    }
+
+    #[inline(always)]
+    fn mark_dirty(&mut self, idx: usize) {
+        if let Some(ref mut bitmap) = self.dirty_bitmap {
+            let page = idx >> 12;
+            bitmap[page / 64] |= 1 << (page % 64);
+        }
     }
 
     pub fn is_empty(&self) -> bool {
@@ -83,21 +108,29 @@ impl<'a> RamView<'a> {
 
     pub fn write_u8(&mut self, physical_address: u64, val: u8) {
         let idx = self.idx(physical_address);
+
+        self.mark_dirty(idx);
         self.ram[idx] = val;
     }
 
     pub fn write_u16(&mut self, physical_address: u64, val: u16) {
         let idx = self.idx(physical_address);
+
+        self.mark_dirty(idx);
         self.ram[idx..idx + 2].copy_from_slice(&val.to_le_bytes());
     }
 
     pub fn write_u32(&mut self, physical_address: u64, val: u32) {
         let idx = self.idx(physical_address);
+
+        self.mark_dirty(idx);
         self.ram[idx..idx + 4].copy_from_slice(&val.to_le_bytes());
     }
 
     pub fn write_u64(&mut self, physical_address: u64, val: u64) {
         let idx = self.idx(physical_address);
+
+        self.mark_dirty(idx);
         self.ram[idx..idx + 8].copy_from_slice(&val.to_le_bytes());
     }
 
@@ -108,6 +141,13 @@ impl<'a> RamView<'a> {
 
     pub fn write_bytes(&mut self, physical_address: u64, buf: &[u8]) {
         let idx = self.idx(physical_address);
+        self.mark_dirty(idx);
+
+        if buf.len() > 4096 {
+            let last_idx = idx + buf.len() - 1;
+            self.mark_dirty(last_idx);
+        }
+
         self.ram[idx..idx + buf.len()].copy_from_slice(buf);
     }
 }

--- a/crates/machine/src/virtio/mod.rs
+++ b/crates/machine/src/virtio/mod.rs
@@ -5,6 +5,7 @@ pub mod net;
 pub mod slirp;
 
 use crate::RAM_BASE;
+use crate::cow_ram::CowRam;
 
 // MMIO v2 register offsets
 pub const MMIO_MAGIC: u64 = 0x000;
@@ -41,38 +42,13 @@ pub const VRING_DESC_F_NEXT: u16 = 1;
 pub const VRING_DESC_F_WRITE: u16 = 2;
 
 pub struct RamView<'a> {
-    ram: &'a mut Vec<u8>,
+    ram: &'a mut CowRam,
     mask: u64,
-    dirty_bitmap: Option<&'a mut Vec<u64>>,
 }
 
 impl<'a> RamView<'a> {
-    pub fn new(ram: &'a mut Vec<u8>, mask: u64) -> Self {
-        Self {
-            ram,
-            mask,
-            dirty_bitmap: None,
-        }
-    }
-
-    pub fn with_dirty_bitmap(
-        ram: &'a mut Vec<u8>,
-        mask: u64,
-        dirty_bitmap: &'a mut Vec<u64>,
-    ) -> Self {
-        Self {
-            ram,
-            mask,
-            dirty_bitmap: Some(dirty_bitmap),
-        }
-    }
-
-    #[inline(always)]
-    fn mark_dirty(&mut self, idx: usize) {
-        if let Some(ref mut bitmap) = self.dirty_bitmap {
-            let page = idx >> 12;
-            bitmap[page / 64] |= 1 << (page % 64);
-        }
+    pub fn new(ram: &'a mut CowRam, mask: u64) -> Self {
+        Self { ram, mask }
     }
 
     pub fn is_empty(&self) -> bool {
@@ -88,67 +64,48 @@ impl<'a> RamView<'a> {
     }
 
     pub fn read_u8(&self, physical_address: u64) -> u8 {
-        self.ram[self.idx(physical_address)]
+        self.ram.read_u8(self.idx(physical_address))
     }
 
     pub fn read_u16(&self, physical_address: u64) -> u16 {
-        let idx = self.idx(physical_address);
-        u16::from_le_bytes(self.ram[idx..idx + 2].try_into().unwrap())
+        self.ram.read_u16(self.idx(physical_address))
     }
 
     pub fn read_u32(&self, physical_address: u64) -> u32 {
-        let idx = self.idx(physical_address);
-        u32::from_le_bytes(self.ram[idx..idx + 4].try_into().unwrap())
+        self.ram.read_u32(self.idx(physical_address))
     }
 
     pub fn read_u64(&self, physical_address: u64) -> u64 {
-        let idx = self.idx(physical_address);
-        u64::from_le_bytes(self.ram[idx..idx + 8].try_into().unwrap())
+        self.ram.read_u64(self.idx(physical_address))
     }
 
     pub fn write_u8(&mut self, physical_address: u64, val: u8) {
         let idx = self.idx(physical_address);
-
-        self.mark_dirty(idx);
-        self.ram[idx] = val;
+        self.ram.write_u8(idx, val);
     }
 
     pub fn write_u16(&mut self, physical_address: u64, val: u16) {
         let idx = self.idx(physical_address);
-
-        self.mark_dirty(idx);
-        self.ram[idx..idx + 2].copy_from_slice(&val.to_le_bytes());
+        self.ram.write_u16(idx, val);
     }
 
     pub fn write_u32(&mut self, physical_address: u64, val: u32) {
         let idx = self.idx(physical_address);
-
-        self.mark_dirty(idx);
-        self.ram[idx..idx + 4].copy_from_slice(&val.to_le_bytes());
+        self.ram.write_u32(idx, val);
     }
 
     pub fn write_u64(&mut self, physical_address: u64, val: u64) {
         let idx = self.idx(physical_address);
-
-        self.mark_dirty(idx);
-        self.ram[idx..idx + 8].copy_from_slice(&val.to_le_bytes());
+        self.ram.write_u64(idx, val);
     }
 
     pub fn read_bytes(&self, physical_address: u64, buf: &mut [u8]) {
-        let idx = self.idx(physical_address);
-        buf.copy_from_slice(&self.ram[idx..idx + buf.len()]);
+        self.ram.read_into(self.idx(physical_address), buf);
     }
 
     pub fn write_bytes(&mut self, physical_address: u64, buf: &[u8]) {
         let idx = self.idx(physical_address);
-        self.mark_dirty(idx);
-
-        if buf.len() > 4096 {
-            let last_idx = idx + buf.len() - 1;
-            self.mark_dirty(last_idx);
-        }
-
-        self.ram[idx..idx + buf.len()].copy_from_slice(buf);
+        self.ram.write_from(idx, buf);
     }
 }
 

--- a/crates/native-cli/src/main.rs
+++ b/crates/native-cli/src/main.rs
@@ -8,6 +8,7 @@ use std::path::PathBuf;
 
 use lz4_flex::frame::FrameEncoder;
 
+use machine::cow_ram::CowRam;
 use machine::machine_bus::{MachineBus, boot};
 use machine::snapshot;
 use riscv_core::Hart;
@@ -114,7 +115,7 @@ fn main() {
     }
 
     let ram_size = ram_mb * 1024 * 1024;
-    let mut bus = MachineBus::new(ram_size);
+    let mut bus = MachineBus::new(ram_size, CowRam::new(ram_size));
     let mut hart = Hart::new(0x1000);
 
     if let Some(path) = &disk_path {

--- a/crates/wasi-component/src/api/executor.rs
+++ b/crates/wasi-component/src/api/executor.rs
@@ -77,17 +77,24 @@ impl Guest for Executor {
         SESSION_MANAGER.close_session(handle);
     }
 
-    fn session_suspend(handle: u64) -> Result<Vec<u8>, String> {
-        SESSION_MANAGER.suspend_session(handle)
+    fn session_suspend(handle: u64, delta_path: String) -> Result<u64, String> {
+        let delta = SESSION_MANAGER.suspend_session(handle)?;
+        std::fs::write(&delta_path, &delta)
+            .map_err(|e| format!("failed to write delta to {delta_path}: {e}"))?;
+
+        Ok(delta.len() as u64)
     }
 
     fn session_resume(
         snapshot_path: String,
-        delta: Vec<u8>,
+        delta_path: String,
         command: String,
         prompt: String,
         mounts: Vec<MountEntry>,
     ) -> Result<u64, String> {
+        let delta = std::fs::read(&delta_path)
+            .map_err(|e| format!("failed to read delta from {delta_path}: {e}"))?;
+
         let mount_args: Vec<vm::MountArg> = mounts
             .into_iter()
             .map(|m| vm::MountArg {

--- a/crates/wasi-component/src/api/executor.rs
+++ b/crates/wasi-component/src/api/executor.rs
@@ -76,4 +76,27 @@ impl Guest for Executor {
     fn session_close(handle: u64) {
         SESSION_MANAGER.close_session(handle);
     }
+
+    fn session_suspend(handle: u64) -> Result<Vec<u8>, String> {
+        SESSION_MANAGER.suspend_session(handle)
+    }
+
+    fn session_resume(
+        snapshot_path: String,
+        delta: Vec<u8>,
+        command: String,
+        prompt: String,
+        mounts: Vec<MountEntry>,
+    ) -> Result<u64, String> {
+        let mount_args: Vec<vm::MountArg> = mounts
+            .into_iter()
+            .map(|m| vm::MountArg {
+                alias: m.host_alias,
+                guest_path: m.guest_path,
+                writable: m.writable,
+            })
+            .collect();
+
+        SESSION_MANAGER.resume_session(snapshot_path, delta, command, prompt, mount_args)
+    }
 }

--- a/crates/wasi-component/src/api/session.rs
+++ b/crates/wasi-component/src/api/session.rs
@@ -226,4 +226,86 @@ impl SessionManager {
     pub fn close_session(&self, handle: u64) {
         self.sessions.borrow_mut().remove(&handle);
     }
+
+    pub fn suspend_session(&self, handle: u64) -> Result<Vec<u8>, String> {
+        let mut sessions = self.sessions.borrow_mut();
+        let session = sessions
+            .remove(&handle)
+            .ok_or_else(|| format!("invalid session handle: {handle}"))?;
+
+        let mut buf = Vec::new();
+        machine::snapshot::save_delta(&session.bus, &session.hart, &mut buf)
+            .map_err(|e| format!("suspend failed: {e}"))?;
+
+        let meta = format!(
+            "{}|{}|{}",
+            if session.is_shell {
+                "shell"
+            } else if session.is_pyrunner {
+                "pyrunner"
+            } else {
+                "custom"
+            },
+            session.has_pyrunner,
+            String::from_utf8_lossy(&session.prompt),
+        );
+
+        let meta_bytes = meta.as_bytes();
+        buf.extend_from_slice(&(meta_bytes.len() as u32).to_le_bytes());
+        buf.extend_from_slice(meta_bytes);
+
+        Ok(buf)
+    }
+
+    pub fn resume_session(
+        &self,
+        snapshot_path: String,
+        delta: Vec<u8>,
+        _command: String,
+        _prompt: String,
+        mount_args: Vec<vm::MountArg>,
+    ) -> Result<u64, String> {
+        let (mut bus, mut hart, _flags) = vm::load(vm::VmConfig {
+            snapshot: snapshot_path.as_ref(),
+            disk: None,
+            mounts: mount_args,
+            capture_tx: true,
+        })?;
+
+        let meta_len_offset = delta.len() - 4;
+        let meta_len = u32::from_le_bytes(delta[meta_len_offset..].try_into().unwrap()) as usize;
+        let meta_offset = meta_len_offset - meta_len;
+        let meta_str = String::from_utf8_lossy(&delta[meta_offset..meta_len_offset]).to_string();
+        let delta_bytes = &delta[..meta_offset];
+
+        let mut cursor = std::io::Cursor::new(delta_bytes);
+        machine::snapshot::restore_delta(&mut bus, &mut hart, &mut cursor)
+            .map_err(|e| format!("resume failed: {e}"))?;
+
+        let parts: Vec<&str> = meta_str.splitn(3, '|').collect();
+        let (is_shell, is_pyrunner, has_pyrunner, prompt) = if parts.len() == 3 {
+            let kind = parts[0];
+            let has_py = parts[1] == "true";
+            let prompt = parts[2].as_bytes().to_vec();
+            (kind == "shell", kind == "pyrunner", has_py, prompt)
+        } else {
+            (true, false, false, b"# ".to_vec())
+        };
+
+        let id = self.next_id.get();
+        self.next_id.set(id + 1);
+        self.sessions.borrow_mut().insert(
+            id,
+            Session {
+                bus,
+                hart,
+                prompt,
+                is_shell,
+                is_pyrunner,
+                has_pyrunner,
+            },
+        );
+
+        Ok(id)
+    }
 }

--- a/crates/wasi-component/src/api/session.rs
+++ b/crates/wasi-component/src/api/session.rs
@@ -19,11 +19,17 @@ pub struct Session {
     pub has_pyrunner: bool,
 }
 
+struct CachedBase {
+    path: String,
+    base: machine::cow_ram::CowRam,
+    tail: Vec<u8>,
+    flags: u8,
+}
+
 pub struct SessionManager {
     sessions: RefCell<HashMap<u64, Session>>,
     next_id: Cell<u64>,
-    snapshot_cache: RefCell<Option<(String, Vec<u8>)>>,
-    base_cache: RefCell<Option<(String, machine::cow_ram::CowRam)>>,
+    base_cache: RefCell<Option<CachedBase>>,
 }
 
 unsafe impl Sync for SessionManager {}
@@ -31,11 +37,27 @@ unsafe impl Sync for SessionManager {}
 pub static SESSION_MANAGER: LazyLock<SessionManager> = LazyLock::new(|| SessionManager {
     sessions: RefCell::new(HashMap::new()),
     next_id: Cell::new(1),
-    snapshot_cache: RefCell::new(None),
     base_cache: RefCell::new(None),
 });
 
 impl SessionManager {
+    fn ensure_base(&self, snapshot_path: &str) -> Result<(), String> {
+        let cache = self.base_cache.borrow();
+        let hit = matches!(&*cache, Some(c) if c.path == snapshot_path);
+        drop(cache);
+
+        if !hit {
+            let (base, tail, flags) = vm::_read_base_and_tail(snapshot_path.as_ref())?;
+            *self.base_cache.borrow_mut() = Some(CachedBase {
+                path: snapshot_path.to_string(),
+                base,
+                tail,
+                flags,
+            });
+        }
+        Ok(())
+    }
+
     pub fn start_session(
         &self,
         snapshot_path: String,
@@ -46,24 +68,19 @@ impl SessionManager {
         let ram_size = vm::ram_size_from_filename(std::path::Path::new(&snapshot_path))
             .unwrap_or(256 * 1024 * 1024);
 
-        {
-            let cache = self.snapshot_cache.borrow();
-            let needs_load = match &*cache {
-                Some((path, _)) => *path != snapshot_path,
-                None => true,
-            };
-            drop(cache);
+        self.ensure_base(&snapshot_path)?;
 
-            if needs_load {
-                let bytes = vm::_read_snapshot_bytes(snapshot_path.as_ref())?;
-                *self.snapshot_cache.borrow_mut() = Some((snapshot_path.clone(), bytes));
-            }
-        }
+        let cache = self.base_cache.borrow();
+        let cached = cache.as_ref().unwrap();
+        let flags = cached.flags;
+        let (mut bus, mut hart) = vm::_bus_from_base(&cached.base, ram_size, &mount_args, true);
 
-        let cache = self.snapshot_cache.borrow();
-        let snapshot_bytes = &cache.as_ref().unwrap().1;
-        let (mut bus, mut hart, flags) =
-            vm::_load_from_bytes(snapshot_bytes, ram_size, &mount_args, true)?;
+        machine::snapshot::restore_devices(
+            &mut bus,
+            &mut hart,
+            &mut std::io::Cursor::new(&cached.tail),
+        )
+            .map_err(|e| format!("failed to restore devices: {e}"))?;
         drop(cache);
 
         let is_shell = command == "/bin/sh" || command == "sh" || command == "/bin/ash";
@@ -288,26 +305,11 @@ impl SessionManager {
         let ram_size = vm::ram_size_from_filename(std::path::Path::new(&snapshot_path))
             .unwrap_or(256 * 1024 * 1024);
 
-        {
-            let cache = self.base_cache.borrow();
-            let needs_load = match &*cache {
-                Some((path, _)) => *path != snapshot_path,
-                None => true,
-            };
-            drop(cache);
-
-            if needs_load {
-                let bytes = vm::_read_snapshot_bytes(snapshot_path.as_ref())?;
-                let (ram_bytes, real_size) = machine::snapshot::base_ram(&bytes)
-                    .map_err(|e| format!("failed to read base RAM: {e}"))?;
-                let base = machine::cow_ram::CowRam::from_base(ram_bytes, real_size);
-                *self.base_cache.borrow_mut() = Some((snapshot_path.clone(), base));
-            }
-        }
+        self.ensure_base(&snapshot_path)?;
 
         let cache = self.base_cache.borrow();
-        let base = &cache.as_ref().unwrap().1;
-        let (mut bus, mut hart) = vm::_bus_from_base(base, ram_size, &mount_args, true);
+        let cached = cache.as_ref().unwrap();
+        let (mut bus, mut hart) = vm::_bus_from_base(&cached.base, ram_size, &mount_args, true);
         drop(cache);
 
         let meta_len_offset = delta.len() - 4;

--- a/crates/wasi-component/src/api/session.rs
+++ b/crates/wasi-component/src/api/session.rs
@@ -80,7 +80,7 @@ impl SessionManager {
             &mut hart,
             &mut std::io::Cursor::new(&cached.tail),
         )
-            .map_err(|e| format!("failed to restore devices: {e}"))?;
+        .map_err(|e| format!("failed to restore devices: {e}"))?;
         drop(cache);
 
         let is_shell = command == "/bin/sh" || command == "sh" || command == "/bin/ash";

--- a/crates/wasi-component/src/api/session.rs
+++ b/crates/wasi-component/src/api/session.rs
@@ -22,6 +22,8 @@ pub struct Session {
 pub struct SessionManager {
     sessions: RefCell<HashMap<u64, Session>>,
     next_id: Cell<u64>,
+    snapshot_cache: RefCell<Option<(String, Vec<u8>)>>,
+    base_cache: RefCell<Option<(String, machine::cow_ram::CowRam)>>,
 }
 
 unsafe impl Sync for SessionManager {}
@@ -29,6 +31,8 @@ unsafe impl Sync for SessionManager {}
 pub static SESSION_MANAGER: LazyLock<SessionManager> = LazyLock::new(|| SessionManager {
     sessions: RefCell::new(HashMap::new()),
     next_id: Cell::new(1),
+    snapshot_cache: RefCell::new(None),
+    base_cache: RefCell::new(None),
 });
 
 impl SessionManager {
@@ -39,12 +43,28 @@ impl SessionManager {
         prompt: String,
         mount_args: Vec<vm::MountArg>,
     ) -> Result<u64, String> {
-        let (mut bus, mut hart, flags) = vm::load(vm::VmConfig {
-            snapshot: snapshot_path.as_ref(),
-            disk: None,
-            mounts: mount_args.clone(),
-            capture_tx: true,
-        })?;
+        let ram_size = vm::ram_size_from_filename(std::path::Path::new(&snapshot_path))
+            .unwrap_or(256 * 1024 * 1024);
+
+        {
+            let cache = self.snapshot_cache.borrow();
+            let needs_load = match &*cache {
+                Some((path, _)) => *path != snapshot_path,
+                None => true,
+            };
+            drop(cache);
+
+            if needs_load {
+                let bytes = vm::_read_snapshot_bytes(snapshot_path.as_ref())?;
+                *self.snapshot_cache.borrow_mut() = Some((snapshot_path.clone(), bytes));
+            }
+        }
+
+        let cache = self.snapshot_cache.borrow();
+        let snapshot_bytes = &cache.as_ref().unwrap().1;
+        let (mut bus, mut hart, flags) =
+            vm::_load_from_bytes(snapshot_bytes, ram_size, &mount_args, true)?;
+        drop(cache);
 
         let is_shell = command == "/bin/sh" || command == "sh" || command == "/bin/ash";
         let is_python = command == "python3" || command == "/usr/bin/python3";
@@ -228,9 +248,9 @@ impl SessionManager {
     }
 
     pub fn suspend_session(&self, handle: u64) -> Result<Vec<u8>, String> {
-        let mut sessions = self.sessions.borrow_mut();
+        let sessions = self.sessions.borrow();
         let session = sessions
-            .remove(&handle)
+            .get(&handle)
             .ok_or_else(|| format!("invalid session handle: {handle}"))?;
 
         let mut buf = Vec::new();
@@ -251,8 +271,8 @@ impl SessionManager {
         );
 
         let meta_bytes = meta.as_bytes();
-        buf.extend_from_slice(&(meta_bytes.len() as u32).to_le_bytes());
         buf.extend_from_slice(meta_bytes);
+        buf.extend_from_slice(&(meta_bytes.len() as u32).to_le_bytes());
 
         Ok(buf)
     }
@@ -265,12 +285,30 @@ impl SessionManager {
         _prompt: String,
         mount_args: Vec<vm::MountArg>,
     ) -> Result<u64, String> {
-        let (mut bus, mut hart, _flags) = vm::load(vm::VmConfig {
-            snapshot: snapshot_path.as_ref(),
-            disk: None,
-            mounts: mount_args,
-            capture_tx: true,
-        })?;
+        let ram_size = vm::ram_size_from_filename(std::path::Path::new(&snapshot_path))
+            .unwrap_or(256 * 1024 * 1024);
+
+        {
+            let cache = self.base_cache.borrow();
+            let needs_load = match &*cache {
+                Some((path, _)) => *path != snapshot_path,
+                None => true,
+            };
+            drop(cache);
+
+            if needs_load {
+                let bytes = vm::_read_snapshot_bytes(snapshot_path.as_ref())?;
+                let (ram_bytes, real_size) = machine::snapshot::base_ram(&bytes)
+                    .map_err(|e| format!("failed to read base RAM: {e}"))?;
+                let base = machine::cow_ram::CowRam::from_base(ram_bytes, real_size);
+                *self.base_cache.borrow_mut() = Some((snapshot_path.clone(), base));
+            }
+        }
+
+        let cache = self.base_cache.borrow();
+        let base = &cache.as_ref().unwrap().1;
+        let (mut bus, mut hart) = vm::_bus_from_base(base, ram_size, &mount_args, true);
+        drop(cache);
 
         let meta_len_offset = delta.len() - 4;
         let meta_len = u32::from_le_bytes(delta[meta_len_offset..].try_into().unwrap()) as usize;
@@ -283,6 +321,17 @@ impl SessionManager {
             .map_err(|e| format!("resume failed: {e}"))?;
 
         let parts: Vec<&str> = meta_str.splitn(3, '|').collect();
+        let prompt_bytes: Vec<u8> = if parts.len() == 3 {
+            parts[2].as_bytes().to_vec()
+        } else {
+            b"# ".to_vec()
+        };
+
+        bus.uart.drain_tx();
+        bus.uart_stderr.drain_tx();
+        bus.uart_ctrl.drain_tx();
+        hart.is_waiting = false;
+        repl::sync_clock(&mut bus, &mut hart, &prompt_bytes);
         let (is_shell, is_pyrunner, has_pyrunner, prompt) = if parts.len() == 3 {
             let kind = parts[0];
             let has_py = parts[1] == "true";
@@ -308,4 +357,54 @@ impl SessionManager {
 
         Ok(id)
     }
+
+    // pub fn resume_fast(&self, handle: u64, delta: Vec<u8>) -> Result<u64, String> {
+    //     let mut sessions = self.sessions.borrow_mut();
+    //     let session = sessions
+    //         .get_mut(&handle)
+    //         .ok_or_else(|| format!("invalid session handle: {handle}"))?;
+
+    //     let meta_len_offset = delta.len() - 4;
+    //     let meta_len = u32::from_le_bytes(delta[meta_len_offset..].try_into().unwrap()) as usize;
+    //     let meta_offset = meta_len_offset - meta_len;
+    //     let meta_str = String::from_utf8_lossy(&delta[meta_offset..meta_len_offset]).to_string();
+    //     let delta_bytes = &delta[..meta_offset];
+
+    //     let cache = self.snapshot_cache.borrow();
+    //     if let Some((_, ref snapshot_bytes)) = *cache {
+    //         let mut cursor = std::io::Cursor::new(snapshot_bytes);
+    //         machine::snapshot::restore(&mut session.bus, &mut session.hart, &mut cursor)
+    //             .map_err(|e| format!("base restore failed: {e}"))?;
+    //     } else {
+    //         return Err("no cached snapshot for fast resume".to_string());
+    //     }
+    //     drop(cache);
+
+    //     let mut cursor = std::io::Cursor::new(delta_bytes);
+    //     machine::snapshot::restore_delta(&mut session.bus, &mut session.hart, &mut cursor)
+    //         .map_err(|e| format!("delta restore failed: {e}"))?;
+
+    //     let parts: Vec<&str> = meta_str.splitn(3, '|').collect();
+    //     let prompt_bytes: Vec<u8> = if parts.len() == 3 {
+    //         parts[2].as_bytes().to_vec()
+    //     } else {
+    //         b"# ".to_vec()
+    //     };
+
+    //     session.bus.uart.drain_tx();
+    //     session.bus.uart_stderr.drain_tx();
+    //     session.bus.uart_ctrl.drain_tx();
+    //     session.hart.is_waiting = false;
+    //     repl::sync_clock(&mut session.bus, &mut session.hart, &prompt_bytes);
+
+    //     if parts.len() == 3 {
+    //         let kind = parts[0];
+    //         session.is_shell = kind == "shell";
+    //         session.is_pyrunner = kind == "pyrunner";
+    //         session.has_pyrunner = parts[1] == "true";
+    //         session.prompt = prompt_bytes;
+    //     }
+
+    //     Ok(handle)
+    // }
 }

--- a/crates/wasi-component/src/vm.rs
+++ b/crates/wasi-component/src/vm.rs
@@ -1,4 +1,5 @@
 use lz4_flex::frame::FrameDecoder;
+use machine::cow_ram::CowRam;
 use machine::machine_bus::MachineBus;
 use machine::snapshot;
 use machine::virtio::fs::Mount;
@@ -48,7 +49,7 @@ pub struct VmConfig<'a> {
     pub capture_tx: bool,
 }
 
-fn ram_size_from_filename(snapshot_path: &Path) -> Option<u64> {
+pub fn ram_size_from_filename(snapshot_path: &Path) -> Option<u64> {
     let stem = snapshot_path.file_stem()?.to_str()?;
     for part in stem.rsplit('-') {
         let lower = part.to_ascii_lowercase();
@@ -90,10 +91,92 @@ fn detect_compression(path: &Path) -> Result<Compression, String> {
     }
 }
 
+pub fn _read_snapshot_bytes(path: &Path) -> Result<Vec<u8>, String> {
+    let file = std::fs::File::open(path)
+        .map_err(|e| format!("failed to open snapshot {:?}: {e}", path))?;
+
+    let mut bytes = Vec::new();
+    match detect_compression(path)? {
+        Compression::Lz4 => {
+            BufReader::new(FrameDecoder::new(file))
+                .read_to_end(&mut bytes)
+                .map_err(|e| format!("failed to read snapshot: {e}"))?;
+        }
+        Compression::Raw => {
+            BufReader::new(file)
+                .read_to_end(&mut bytes)
+                .map_err(|e| format!("failed to read snapshot: {e}"))?;
+        }
+    }
+    Ok(bytes)
+}
+
+pub fn _load_from_bytes(
+    snapshot_bytes: &[u8],
+    ram_size: u64,
+    mounts: &[MountArg],
+    capture_tx: bool,
+) -> Result<(MachineBus, Hart, u8), String> {
+    let mut bus = MachineBus::new(ram_size, CowRam::new(ram_size));
+    bus.attach_net();
+    bus.attach_fs(vec![]);
+    let mut hart = Hart::new(0x1000);
+
+    let mut cursor = std::io::Cursor::new(snapshot_bytes);
+    let flags = snapshot::restore(&mut bus, &mut hart, &mut cursor)
+        .map_err(|e| format!("failed to restore snapshot: {e}"))?;
+
+    for (i, m) in mounts.iter().enumerate() {
+        if let Some(fs) = bus.fs_devices.get_mut(i) {
+            fs.set_mounts(vec![Mount {
+                host_path: PathBuf::from(&m.alias),
+                tag: format!("vfs{}", i),
+                writable: m.writable,
+            }]);
+        }
+    }
+
+    bus.uart.capture_tx.set(capture_tx);
+    bus.uart_stderr.capture_tx.set(true);
+    bus.uart_ctrl.capture_tx.set(true);
+    bus.uart_data.capture_tx.set(true);
+
+    Ok((bus, hart, flags))
+}
+
+pub fn _bus_from_base(
+    base: &CowRam,
+    ram_size: u64,
+    mounts: &[MountArg],
+    capture_tx: bool,
+) -> (MachineBus, Hart) {
+    let mut bus = MachineBus::new(ram_size, base.clone_shared());
+    bus.attach_net();
+    bus.attach_fs(vec![]);
+    let hart = Hart::new(0x1000);
+
+    for (i, m) in mounts.iter().enumerate() {
+        if let Some(fs) = bus.fs_devices.get_mut(i) {
+            fs.set_mounts(vec![Mount {
+                host_path: PathBuf::from(&m.alias),
+                tag: format!("vfs{}", i),
+                writable: m.writable,
+            }]);
+        }
+    }
+
+    bus.uart.capture_tx.set(capture_tx);
+    bus.uart_stderr.capture_tx.set(true);
+    bus.uart_ctrl.capture_tx.set(true);
+    bus.uart_data.capture_tx.set(true);
+
+    (bus, hart)
+}
+
 pub fn load(config: VmConfig) -> Result<(MachineBus, Hart, u8), String> {
     let ram_size = ram_size_from_filename(config.snapshot).unwrap_or(256 * 1024 * 1024);
 
-    let mut bus = MachineBus::new(ram_size);
+    let mut bus = MachineBus::new(ram_size, CowRam::new(ram_size));
     bus.attach_net();
     bus.attach_fs(vec![]);
     let mut hart = Hart::new(0x1000);

--- a/crates/wasi-component/src/vm.rs
+++ b/crates/wasi-component/src/vm.rs
@@ -91,57 +91,17 @@ fn detect_compression(path: &Path) -> Result<Compression, String> {
     }
 }
 
-pub fn _read_snapshot_bytes(path: &Path) -> Result<Vec<u8>, String> {
+pub fn _read_base_and_tail(path: &Path) -> Result<(CowRam, Vec<u8>, u8), String> {
     let file = std::fs::File::open(path)
         .map_err(|e| format!("failed to open snapshot {:?}: {e}", path))?;
 
-    let mut bytes = Vec::new();
     match detect_compression(path)? {
         Compression::Lz4 => {
-            BufReader::new(FrameDecoder::new(file))
-                .read_to_end(&mut bytes)
-                .map_err(|e| format!("failed to read snapshot: {e}"))?;
+            snapshot::load_base_and_tail(&mut BufReader::new(FrameDecoder::new(file)))
         }
-        Compression::Raw => {
-            BufReader::new(file)
-                .read_to_end(&mut bytes)
-                .map_err(|e| format!("failed to read snapshot: {e}"))?;
-        }
+        Compression::Raw => snapshot::load_base_and_tail(&mut BufReader::new(file)),
     }
-    Ok(bytes)
-}
-
-pub fn _load_from_bytes(
-    snapshot_bytes: &[u8],
-    ram_size: u64,
-    mounts: &[MountArg],
-    capture_tx: bool,
-) -> Result<(MachineBus, Hart, u8), String> {
-    let mut bus = MachineBus::new(ram_size, CowRam::new(ram_size));
-    bus.attach_net();
-    bus.attach_fs(vec![]);
-    let mut hart = Hart::new(0x1000);
-
-    let mut cursor = std::io::Cursor::new(snapshot_bytes);
-    let flags = snapshot::restore(&mut bus, &mut hart, &mut cursor)
-        .map_err(|e| format!("failed to restore snapshot: {e}"))?;
-
-    for (i, m) in mounts.iter().enumerate() {
-        if let Some(fs) = bus.fs_devices.get_mut(i) {
-            fs.set_mounts(vec![Mount {
-                host_path: PathBuf::from(&m.alias),
-                tag: format!("vfs{}", i),
-                writable: m.writable,
-            }]);
-        }
-    }
-
-    bus.uart.capture_tx.set(capture_tx);
-    bus.uart_stderr.capture_tx.set(true);
-    bus.uart_ctrl.capture_tx.set(true);
-    bus.uart_data.capture_tx.set(true);
-
-    Ok((bus, hart, flags))
+    .map_err(|e| format!("failed to load snapshot base: {e}"))
 }
 
 pub fn _bus_from_base(

--- a/crates/wasi-component/vpod.wit
+++ b/crates/wasi-component/vpod.wit
@@ -22,4 +22,7 @@ interface executor {
     session-start: func(snapshot-path: string, command: string, prompt: string, mounts: list<mount-entry>) -> result<u64, string>;
     session-exec: func(handle: u64, code: string) -> result<execution-result, string>;
     session-close: func(handle: u64);
+
+    session-suspend: func(handle: u64) -> result<list<u8>, string>;
+    session-resume: func(snapshot-path: string, delta: list<u8>, command: string, prompt: string, mounts: list<mount-entry>) -> result<u64, string>;
 }

--- a/crates/wasi-component/vpod.wit
+++ b/crates/wasi-component/vpod.wit
@@ -23,6 +23,6 @@ interface executor {
     session-exec: func(handle: u64, code: string) -> result<execution-result, string>;
     session-close: func(handle: u64);
 
-    session-suspend: func(handle: u64) -> result<list<u8>, string>;
-    session-resume: func(snapshot-path: string, delta: list<u8>, command: string, prompt: string, mounts: list<mount-entry>) -> result<u64, string>;
+    session-suspend: func(handle: u64, delta-path: string) -> result<u64, string>;
+    session-resume: func(snapshot-path: string, delta-path: string, command: string, prompt: string, mounts: list<mount-entry>) -> result<u64, string>;
 }

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -89,6 +89,7 @@ sbx.code.run("import numpy; print(numpy.__version__)")
 | `sandbox.suspend()` | Suspend to disk, returns instance ID |
 | `Sandbox.resume(id)` | Resume a suspended instance |
 | `Sandbox.list_instances()` | List all instances |
+| `Sandbox.destroy(id)` | Delete a suspended instance from disk |
 
 ### Shell commands (stateless)
 

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -88,7 +88,7 @@ sbx.code.run("import numpy; print(numpy.__version__)")
 |:---|:---|
 | `sandbox.suspend()` | Suspend to disk, returns instance ID |
 | `Sandbox.resume(id)` | Resume a suspended instance |
-| `Sandbox.list_sessions()` | List all instances |
+| `Sandbox.list_instances()` | List all instances |
 
 ### Shell commands (stateless)
 

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -68,6 +68,28 @@ with Sandbox.create(snapshot="vsnap-data", mounts=mounts) as sbx:
     sbx.code.run("print('Pandas is ready!')")
 ```
 
+### Suspend & Resume
+
+Pause a running sandbox and resume it later — no daemon, no background process. Only dirty memory pages are saved, making it fast and storage-efficient.
+
+```python
+from vpod import Sandbox
+
+with Sandbox.create() as sbx:
+    sbx.commands.run("pip install numpy")
+    instance_id = sbx.suspend()
+
+# Later (even from a new process):
+sbx = Sandbox.resume(instance_id)
+sbx.code.run("import numpy; print(numpy.__version__)")
+```
+
+| Method | Description |
+|:---|:---|
+| `sandbox.suspend()` | Suspend to disk, returns instance ID |
+| `Sandbox.resume(id)` | Resume a suspended instance |
+| `Sandbox.list_instances()` | List all instances |
+
 ### Shell commands (stateless)
 
 If you just need a quick one-off execution without preserving state:

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -88,7 +88,7 @@ sbx.code.run("import numpy; print(numpy.__version__)")
 |:---|:---|
 | `sandbox.suspend()` | Suspend to disk, returns instance ID |
 | `Sandbox.resume(id)` | Resume a suspended instance |
-| `Sandbox.list_instances()` | List all instances |
+| `Sandbox.list_sessions()` | List all instances |
 
 ### Shell commands (stateless)
 

--- a/sdks/python/tests/test_instance.py
+++ b/sdks/python/tests/test_instance.py
@@ -34,12 +34,12 @@ def test_suspend_and_resume_preserves_files():
     sbx.close()
 
 
-def test_list_sessions_shows_suspended():
+def test_list_instances_shows_suspended():
     with Sandbox.create() as sbx:
         sbx.commands.run("echo test")
         instance_id = sbx.suspend()
 
-    instances = Sandbox.list_sessions()
+    instances = Sandbox.list_instances()
     ids = [e["id"] for e in instances]
     assert instance_id in ids
 
@@ -53,7 +53,7 @@ def test_resume_updates_state_to_running():
 
     sbx = Sandbox.resume(instance_id)
 
-    instances = Sandbox.list_sessions()
+    instances = Sandbox.list_instances()
     entry = next(e for e in instances if e["id"] == instance_id)
     assert entry["state"] == "RUNNING"
     sbx.close()
@@ -65,7 +65,7 @@ def test_destroy_removes_instance():
 
     Sandbox.destroy(instance_id)
 
-    instances = Sandbox.list_sessions()
+    instances = Sandbox.list_instances()
     ids = [e["id"] for e in instances]
     assert instance_id not in ids
 

--- a/sdks/python/tests/test_instance.py
+++ b/sdks/python/tests/test_instance.py
@@ -1,0 +1,124 @@
+import pytest
+from vpod import Sandbox
+
+pytestmark = pytest.mark.integration
+
+
+def test_suspend_returns_instance_id():
+    with Sandbox.create() as sbx:
+        sbx.commands.run("echo warmup")
+        instance_id = sbx.suspend()
+        assert instance_id is not None
+        assert len(instance_id) == 36
+
+
+def test_suspend_and_resume_preserves_env():
+    with Sandbox.create() as sbx:
+        sbx.commands.run("export MY_VAR=persisted")
+        instance_id = sbx.suspend()
+
+    sbx = Sandbox.resume(instance_id)
+    result = sbx.commands.run("echo $MY_VAR")
+    assert "persisted" in result.stdout
+    sbx.close()
+
+
+def test_suspend_and_resume_preserves_files():
+    with Sandbox.create() as sbx:
+        sbx.commands.run("echo hello > /tmp/survive.txt")
+        instance_id = sbx.suspend()
+
+    sbx = Sandbox.resume(instance_id)
+    result = sbx.commands.run("cat /tmp/survive.txt")
+    assert "hello" in result.stdout
+    sbx.close()
+
+
+def test_list_sessions_shows_suspended():
+    with Sandbox.create() as sbx:
+        sbx.commands.run("echo test")
+        instance_id = sbx.suspend()
+
+    instances = Sandbox.list_sessions()
+    ids = [e["id"] for e in instances]
+    assert instance_id in ids
+
+    entry = next(e for e in instances if e["id"] == instance_id)
+    assert entry["state"] == "SUSPENDED"
+
+
+def test_resume_updates_state_to_running():
+    with Sandbox.create() as sbx:
+        instance_id = sbx.suspend()
+
+    sbx = Sandbox.resume(instance_id)
+
+    instances = Sandbox.list_sessions()
+    entry = next(e for e in instances if e["id"] == instance_id)
+    assert entry["state"] == "RUNNING"
+    sbx.close()
+
+
+def test_destroy_removes_instance():
+    with Sandbox.create() as sbx:
+        instance_id = sbx.suspend()
+
+    Sandbox.destroy(instance_id)
+
+    instances = Sandbox.list_sessions()
+    ids = [e["id"] for e in instances]
+    assert instance_id not in ids
+
+
+def test_resume_nonexistent_instance_fails():
+    with pytest.raises(Exception):
+        Sandbox.resume("nonexistent-id-000-000-000000000000")
+
+
+def test_multiple_suspend_resume_cycles():
+    with Sandbox.create() as sbx:
+        sbx.commands.run("export COUNTER=1")
+        id1 = sbx.suspend()
+
+    sbx = Sandbox.resume(id1)
+    sbx.commands.run("export COUNTER=2")
+    id2 = sbx.suspend()
+
+    sbx = Sandbox.resume(id2)
+    result = sbx.commands.run("echo $COUNTER")
+    assert "2" in result.stdout
+    sbx.close()
+
+
+def test_suspend_resume_python_state():
+    with Sandbox.create() as sbx:
+        sbx.code.run("x = 42")
+        sbx.code.run("data = [1, 2, 3]")
+        instance_id = sbx.suspend()
+
+    sbx = Sandbox.resume(instance_id)
+    result = sbx.code.run("print(x + sum(data))")
+    assert "48" in result.text
+    sbx.close()
+
+
+def test_independent_instances_isolated():
+    with Sandbox.create() as sbx1:
+        sbx1.commands.run("echo instance1 > /tmp/who.txt")
+        id1 = sbx1.suspend()
+
+    with Sandbox.create() as sbx2:
+        sbx2.commands.run("echo instance2 > /tmp/who.txt")
+        id2 = sbx2.suspend()
+
+    restored1 = Sandbox.resume(id1)
+    restored2 = Sandbox.resume(id2)
+
+    r1 = restored1.commands.run("cat /tmp/who.txt")
+    r2 = restored2.commands.run("cat /tmp/who.txt")
+
+    assert "instance1" in r1.stdout
+    assert "instance2" in r2.stdout
+
+    restored1.close()
+    restored2.close()

--- a/sdks/python/vpod/__init__.py
+++ b/sdks/python/vpod/__init__.py
@@ -1,5 +1,5 @@
-from .sandbox import Sandbox
+from .sandbox import Sandbox, INSTANCES_DIR
 from .execution import CommandResult, CodeExecution
 
 __version__ = "0.0.0"
-__all__ = ["Sandbox", "CommandResult", "CodeExecution"]
+__all__ = ["Sandbox", "INSTANCES_DIR", "CommandResult", "CodeExecution"]

--- a/sdks/python/vpod/_component.py
+++ b/sdks/python/vpod/_component.py
@@ -17,6 +17,7 @@ except Exception:
 
 _engine = None
 _component = None
+_linker = None
 
 
 def locate_wasm() -> Path:
@@ -62,7 +63,7 @@ def _load_or_compile_component(engine: Engine, wasm_path: Path) -> Component:
 
 
 def _get_or_load_component(wasm_path: Path):
-    global _engine, _component
+    global _engine, _component, _linker
 
     if _engine is None:
         _engine = Engine()
@@ -70,14 +71,18 @@ def _get_or_load_component(wasm_path: Path):
     if _component is None:
         _component = _load_or_compile_component(_engine, wasm_path)
 
-    return _engine, _component
+    if _linker is None:
+        _linker = Linker(_engine)
+        _linker.add_wasip2()
+
+    return _engine, _component, _linker
 
 
 def load_component(wasm_path: Path, snapshot_path: Path = None, mount_dirs: list[str] | None = None):
     from . import snapshots as _snapshots
     snap_dir = str(_snapshots.cache_dir()) if snapshot_path is None else str(snapshot_path.parent)
 
-    engine, component = _get_or_load_component(wasm_path)
+    engine, component, linker = _get_or_load_component(wasm_path)
 
     store = Store(engine)
     wasi = WasiConfig()
@@ -92,9 +97,6 @@ def load_component(wasm_path: Path, snapshot_path: Path = None, mount_dirs: list
 
     wasi_config_inherit_network(wasi.ptr())
     store.set_wasi(wasi)
-
-    linker = Linker(engine)
-    linker.add_wasip2()
 
     instance = linker.instantiate(store, component)
 

--- a/sdks/python/vpod/_component.py
+++ b/sdks/python/vpod/_component.py
@@ -18,6 +18,7 @@ except Exception:
 _engine = None
 _component = None
 _linker = None
+_instance_cache = {}
 
 
 def locate_wasm() -> Path:
@@ -78,9 +79,38 @@ def _get_or_load_component(wasm_path: Path):
     return _engine, _component, _linker
 
 
+def _resolve_exports(store, instance):
+    iface_index = instance.get_export_index(store, "vpod:sandbox/executor@0.1.0")
+    if iface_index is None:
+        raise RuntimeError("WASM component does not export 'vpod:sandbox/executor@0.1.0'")
+
+    def get_export(name: str):
+        idx = instance.get_export_index(store, name, iface_index)
+        if idx is None:
+            raise RuntimeError(f"WASM export '{name}' not found in executor interface")
+        func = instance.get_func(store, idx)
+        if func is None:
+            raise RuntimeError(f"WASM export '{name}' is not a function")
+        return lambda *args: func(store, *args)
+
+    return {name: get_export(name) for name in ("execute", "session-start", "session-exec", "session-close", "session-suspend", "session-resume")}
+
+
+def _instance_key(snap_dir: str, mount_dirs: list[str] | None) -> str:
+    parts = [snap_dir]
+    if mount_dirs:
+        parts.extend(sorted(mount_dirs))
+    return "|".join(parts)
+
+
 def load_component(wasm_path: Path, snapshot_path: Path = None, mount_dirs: list[str] | None = None):
     from . import snapshots as _snapshots
     snap_dir = str(_snapshots.cache_dir()) if snapshot_path is None else str(snapshot_path.parent)
+
+    key = _instance_key(snap_dir, mount_dirs)
+
+    if key in _instance_cache:
+        return _instance_cache[key]
 
     engine, component, linker = _get_or_load_component(wasm_path)
 
@@ -99,20 +129,8 @@ def load_component(wasm_path: Path, snapshot_path: Path = None, mount_dirs: list
     store.set_wasi(wasi)
 
     instance = linker.instantiate(store, component)
+    exports = _resolve_exports(store, instance)
 
-    iface_index = instance.get_export_index(store, "vpod:sandbox/executor@0.1.0")
-    if iface_index is None:
-        raise RuntimeError("WASM component does not export 'vpod:sandbox/executor@0.1.0'")
-
-    def get_export(name: str):
-        idx = instance.get_export_index(store, name, iface_index)
-        if idx is None:
-            raise RuntimeError(f"WASM export '{name}' not found in executor interface")
-        func = instance.get_func(store, idx)
-        if func is None:
-            raise RuntimeError(f"WASM export '{name}' is not a function")
-        return lambda *args: func(store, *args)
-
-    exports = {name: get_export(name) for name in ("execute", "session-start", "session-exec", "session-close", "session-suspend", "session-resume")}
+    _instance_cache[key] = (store, exports)
 
     return store, exports

--- a/sdks/python/vpod/_component.py
+++ b/sdks/python/vpod/_component.py
@@ -121,6 +121,10 @@ def load_component(wasm_path: Path, snapshot_path: Path = None, mount_dirs: list
     wasi.inherit_stdin()
     wasi.preopen_dir(snap_dir, "snap")
 
+    instances_dir = Path.home() / ".vpod" / "instances"
+    instances_dir.mkdir(parents=True, exist_ok=True)
+    wasi.preopen_dir(str(instances_dir), "instances")
+
     if mount_dirs:
         for i, dir_path in enumerate(mount_dirs):
             wasi.preopen_dir(dir_path, f"mount{i}")

--- a/sdks/python/vpod/_component.py
+++ b/sdks/python/vpod/_component.py
@@ -111,6 +111,6 @@ def load_component(wasm_path: Path, snapshot_path: Path = None, mount_dirs: list
             raise RuntimeError(f"WASM export '{name}' is not a function")
         return lambda *args: func(store, *args)
 
-    exports = {name: get_export(name) for name in ("execute", "session-start", "session-exec", "session-close")}
+    exports = {name: get_export(name) for name in ("execute", "session-start", "session-exec", "session-close", "session-suspend", "session-resume")}
 
     return store, exports

--- a/sdks/python/vpod/sandbox.py
+++ b/sdks/python/vpod/sandbox.py
@@ -1,4 +1,7 @@
+import json
+import uuid
 from os.path import abspath
+from pathlib import Path
 from typing import Optional
 
 from . import snapshots
@@ -6,6 +9,8 @@ from ._component import load_component, locate_wasm
 from ._result import unwrap_result as _unwrap_result
 from .code import Code
 from .commands import Commands
+
+INSTANCES_DIR = Path.home() / ".vpod" / "instances"
 
 
 def _parse_mounts(mounts: dict[str, str]) -> list[dict]:
@@ -108,3 +113,98 @@ class Sandbox:
 
     def close(self) -> None:
         self.__exit__()
+
+    def suspend(self) -> str:
+        session_id = self._get_shell_session_id()
+        result = self._exports["session-suspend"](session_id)
+        delta_bytes = bytes(_unwrap_result(result))
+
+        instance_id = str(uuid.uuid4())
+        instance_dir = INSTANCES_DIR / instance_id
+        instance_dir.mkdir(parents=True, exist_ok=True)
+
+        (instance_dir / "delta.bin").write_bytes(delta_bytes)
+        (instance_dir / "meta.json").write_text(json.dumps({
+            "snapshot": self._snapshot_path,
+            "mounts": self._mounts,
+            "state": "SUSPENDED",
+        }))
+
+        self._shell_session_id = None
+        self._update_manifest(instance_id, "SUSPENDED")
+        return instance_id
+
+    @classmethod
+    def resume(cls, instance_id: str, mounts: dict[str, str] | None = None) -> "Sandbox":
+        instance_dir = INSTANCES_DIR / instance_id
+        meta = json.loads((instance_dir / "meta.json").read_text())
+        delta_bytes = (instance_dir / "delta.bin").read_bytes()
+
+        snapshot_name = meta["snapshot"].removeprefix("snap/")
+        snapshot_path = snapshots.pull(snapshot_name)
+        wasm_path = locate_wasm()
+
+        saved_mounts = _parse_mounts(mounts) if mounts else meta.get("mounts", [])
+        mount_dirs = [m["host_path"] for m in saved_mounts]
+        store, exports = load_component(wasm_path, snapshot_path, mount_dirs or None)
+
+        mount_entries = []
+        for i, m in enumerate(saved_mounts):
+            entry = object.__new__(type("MountEntry", (), {}))
+            object.__setattr__(entry, "host-alias", f"mount{i}")
+            object.__setattr__(entry, "guest-path", m["guest_path"])
+            object.__setattr__(entry, "writable", m["writable"])
+            mount_entries.append(entry)
+
+        snap_rel = "snap/" + snapshot_path.name
+        result = exports["session-resume"](
+            snap_rel, list(delta_bytes), _DEFAULT_SHELL, _DEFAULT_PROMPT, mount_entries
+        )
+        session_id = int(_unwrap_result(result))
+
+        instance = cls.__new__(cls)
+        instance._snapshot_path = snap_rel
+        instance._mounts = saved_mounts
+        instance._store = store
+        instance._exports = exports
+        instance._shell_session_id = session_id
+        instance._in_context = False
+        instance.commands = Commands(exports, snap_rel, instance._get_shell_session_id)
+        instance.code = Code(exports, snap_rel, instance._get_code_session_id)
+
+        cls._update_manifest(instance_id, "RUNNING")
+        return instance
+
+    def destroy(self, instance_id: str) -> None:
+        """Remove a suspended instance from disk."""
+        import shutil
+        instance_dir = INSTANCES_DIR / instance_id
+        if instance_dir.exists():
+            shutil.rmtree(instance_dir)
+        self._remove_from_manifest(instance_id)
+
+    @staticmethod
+    def list_instances() -> list[dict]:
+        """List all suspended/running instances."""
+        manifest_path = INSTANCES_DIR / "manifest.json"
+        if not manifest_path.exists():
+            return []
+        return json.loads(manifest_path.read_text())
+
+    @staticmethod
+    def _update_manifest(instance_id: str, state: str) -> None:
+        INSTANCES_DIR.mkdir(parents=True, exist_ok=True)
+        manifest_path = INSTANCES_DIR / "manifest.json"
+        entries = json.loads(manifest_path.read_text()) if manifest_path.exists() else []
+        entries = [e for e in entries if e["id"] != instance_id]
+        entries.append({"id": instance_id, "state": state})
+        manifest_path.write_text(json.dumps(entries, indent=2))
+
+    @staticmethod
+    def _remove_from_manifest(instance_id: str) -> None:
+        manifest_path = INSTANCES_DIR / "manifest.json"
+        if not manifest_path.exists():
+            return
+        entries = json.loads(manifest_path.read_text())
+        entries = [e for e in entries if e["id"] != instance_id]
+        manifest_path.write_text(json.dumps(entries, indent=2))

--- a/sdks/python/vpod/sandbox.py
+++ b/sdks/python/vpod/sandbox.py
@@ -216,7 +216,7 @@ class Sandbox:
         Sandbox._remove_from_manifest(instance_id)
 
     @staticmethod
-    def list_sessions() -> list[dict]:
+    def list_instances() -> list[dict]:
         """List all suspended/running instances."""
         manifest_path = INSTANCES_DIR / "manifest.json"
         if not manifest_path.exists():

--- a/sdks/python/vpod/sandbox.py
+++ b/sdks/python/vpod/sandbox.py
@@ -1,3 +1,4 @@
+from asyncio import selector_events
 import json
 import uuid
 from os.path import abspath
@@ -5,6 +6,7 @@ from pathlib import Path
 from typing import Optional
 
 from . import snapshots
+from .snapshots import cache_dir
 from ._component import load_component, locate_wasm
 from ._result import unwrap_result as _unwrap_result
 from .code import Code
@@ -76,7 +78,7 @@ class Sandbox:
         )
 
     @classmethod
-    def create(cls, snapshot: str = "alpine:latest", mounts: dict[str, str] | None = None) -> "Sandbox":
+    def create(cls, snapshot: str = "vsnap-base:latest", mounts: dict[str, str] | None = None) -> "Sandbox":
         return cls(snapshot, mounts=mounts)
 
     def _get_shell_session_id(self) -> int:
@@ -114,6 +116,14 @@ class Sandbox:
     def close(self) -> None:
         self.__exit__()
 
+    def _snapshot_sha256(self) -> str:
+        snapshot_name = self._snapshot_path.removeprefix("snap/")
+        snap_file = cache_dir() / snapshot_name
+        meta_file = snap_file.with_suffix(".meta")
+        if meta_file.exists():
+            return meta_file.read_text().strip()
+        return ""
+
     def suspend(self) -> str:
         session_id = self._get_shell_session_id()
         result = self._exports["session-suspend"](session_id)
@@ -126,6 +136,7 @@ class Sandbox:
         (instance_dir / "delta.bin").write_bytes(delta_bytes)
         (instance_dir / "meta.json").write_text(json.dumps({
             "snapshot": self._snapshot_path,
+            "snapshot_sha256": self._snapshot_sha256(),
             "mounts": self._mounts,
             "state": "SUSPENDED",
         }))
@@ -142,6 +153,17 @@ class Sandbox:
 
         snapshot_name = meta["snapshot"].removeprefix("snap/")
         snapshot_path = snapshots.pull(snapshot_name)
+
+        expected_hash = meta.get("snapshot_sha256", "")
+        if expected_hash:
+            meta_file = snapshot_path.with_suffix(".meta")
+            current_hash = meta_file.read_text().strip() if meta_file.exists() else ""
+            if current_hash and current_hash != expected_hash:
+                raise RuntimeError(
+                    f"Snapshot changed since suspend (expected {expected_hash[:12]}…, "
+                    f"got {current_hash[:12]}…). The delta is no longer valid."
+                )
+
         wasm_path = locate_wasm()
 
         saved_mounts = _parse_mounts(mounts) if mounts else meta.get("mounts", [])
@@ -158,7 +180,7 @@ class Sandbox:
 
         snap_rel = "snap/" + snapshot_path.name
         result = exports["session-resume"](
-            snap_rel, list(delta_bytes), _DEFAULT_SHELL, _DEFAULT_PROMPT, mount_entries
+            snap_rel, bytes(delta_bytes), _DEFAULT_SHELL, _DEFAULT_PROMPT, mount_entries
         )
         session_id = int(_unwrap_result(result))
 
@@ -168,20 +190,21 @@ class Sandbox:
         instance._store = store
         instance._exports = exports
         instance._shell_session_id = session_id
-        instance._in_context = False
+        instance._in_context = True
         instance.commands = Commands(exports, snap_rel, instance._get_shell_session_id)
         instance.code = Code(exports, snap_rel, instance._get_code_session_id)
 
         cls._update_manifest(instance_id, "RUNNING")
         return instance
 
-    def destroy(self, instance_id: str) -> None:
+    @staticmethod
+    def destroy(instance_id: str) -> None:
         """Remove a suspended instance from disk."""
         import shutil
         instance_dir = INSTANCES_DIR / instance_id
         if instance_dir.exists():
             shutil.rmtree(instance_dir)
-        self._remove_from_manifest(instance_id)
+        Sandbox._remove_from_manifest(instance_id)
 
     @staticmethod
     def list_instances() -> list[dict]:

--- a/sdks/python/vpod/sandbox.py
+++ b/sdks/python/vpod/sandbox.py
@@ -1,4 +1,3 @@
-from asyncio import selector_events
 import json
 import uuid
 from os.path import abspath
@@ -207,7 +206,7 @@ class Sandbox:
         Sandbox._remove_from_manifest(instance_id)
 
     @staticmethod
-    def list_instances() -> list[dict]:
+    def list_sessions() -> list[dict]:
         """List all suspended/running instances."""
         manifest_path = INSTANCES_DIR / "manifest.json"
         if not manifest_path.exists():

--- a/sdks/python/vpod/sandbox.py
+++ b/sdks/python/vpod/sandbox.py
@@ -125,14 +125,14 @@ class Sandbox:
 
     def suspend(self) -> str:
         session_id = self._get_shell_session_id()
-        result = self._exports["session-suspend"](session_id)
-        delta_bytes = bytes(_unwrap_result(result))
 
         instance_id = str(uuid.uuid4())
         instance_dir = INSTANCES_DIR / instance_id
         instance_dir.mkdir(parents=True, exist_ok=True)
 
-        (instance_dir / "delta.bin").write_bytes(delta_bytes)
+        delta_rel = f"instances/{instance_id}/delta.bin"
+        _unwrap_result(self._exports["session-suspend"](session_id, delta_rel))
+
         (instance_dir / "meta.json").write_text(json.dumps({
             "snapshot": self._snapshot_path,
             "snapshot_sha256": self._snapshot_sha256(),
@@ -148,7 +148,7 @@ class Sandbox:
     def resume(cls, instance_id: str, mounts: dict[str, str] | None = None) -> "Sandbox":
         instance_dir = INSTANCES_DIR / instance_id
         meta = json.loads((instance_dir / "meta.json").read_text())
-        delta_bytes = (instance_dir / "delta.bin").read_bytes()
+        delta_rel = f"instances/{instance_id}/delta.bin"
 
         snapshot_name = meta["snapshot"].removeprefix("snap/")
         snapshot_path = snapshots.pull(snapshot_name)
@@ -179,7 +179,7 @@ class Sandbox:
 
         snap_rel = "snap/" + snapshot_path.name
         result = exports["session-resume"](
-            snap_rel, bytes(delta_bytes), _DEFAULT_SHELL, _DEFAULT_PROMPT, mount_entries
+            snap_rel, delta_rel, _DEFAULT_SHELL, _DEFAULT_PROMPT, mount_entries
         )
         session_id = int(_unwrap_result(result))
 

--- a/sdks/python/vpod/sandbox.py
+++ b/sdks/python/vpod/sandbox.py
@@ -1,4 +1,5 @@
 import json
+import os
 import uuid
 from os.path import abspath
 from pathlib import Path
@@ -150,8 +151,17 @@ class Sandbox:
         meta = json.loads((instance_dir / "meta.json").read_text())
         delta_rel = f"instances/{instance_id}/delta.bin"
 
-        snapshot_name = meta["snapshot"].removeprefix("snap/").removesuffix(".snap")
-        snapshot_path = snapshots.pull(snapshot_name)
+
+        snapshot_file = meta["snapshot"].removeprefix("snap/")
+        override = os.environ.get("VPOD_SNAPSHOT")
+        if override and Path(override).exists():
+            snapshot_path = Path(override)
+        else:
+            cached = cache_dir() / snapshot_file
+            snapshot_path = (
+                cached if cached.exists()
+                else snapshots.pull(snapshot_file.removesuffix(".snap"))
+            )
 
         expected_hash = meta.get("snapshot_sha256", "")
         if expected_hash:

--- a/sdks/python/vpod/sandbox.py
+++ b/sdks/python/vpod/sandbox.py
@@ -150,7 +150,7 @@ class Sandbox:
         meta = json.loads((instance_dir / "meta.json").read_text())
         delta_rel = f"instances/{instance_id}/delta.bin"
 
-        snapshot_name = meta["snapshot"].removeprefix("snap/")
+        snapshot_name = meta["snapshot"].removeprefix("snap/").removesuffix(".snap")
         snapshot_path = snapshots.pull(snapshot_name)
 
         expected_hash = meta.get("snapshot_sha256", "")


### PR DESCRIPTION
Need a daemon-like semantics (suspend a running VM, resume it later, list active session) without introducing a background process, socket, or any runtime infrastructure. The system will be lightweight: a simple WASM save/restore snapshot loaded in-process by the Python SDK.