### PR TITLE
Reseed the guest crng on resume 

### DIFF
--- a/crates/wasi-component/src/api/session.rs
+++ b/crates/wasi-component/src/api/session.rs
@@ -50,6 +50,7 @@ pub struct Session {
     pub is_pyrunner: bool,
     pub has_pyrunner: bool,
     pub pyrunner_dirty: bool,
+    pub pyrunner_reseeded: bool,
     pub shell_lost: bool,
     pub exec: Option<repl::ExecState>,
 }
@@ -316,7 +317,7 @@ impl SessionManager {
                 bus.uart.drain_tx();
                 repl::shell_init(&mut bus, &mut hart, &prompt_bytes);
             } else {
-                repl::sync_clock(&mut bus, &mut hart, &prompt_bytes);
+                repl::sync_clock_and_reseed(&mut bus, &mut hart, &prompt_bytes);
             }
         } else if use_pyrunner {
             if !shell_ready {
@@ -376,6 +377,7 @@ impl SessionManager {
                 is_pyrunner: use_pyrunner,
                 has_pyrunner: python_ready,
                 pyrunner_dirty: false,
+                pyrunner_reseeded: false,
                 shell_lost: false,
                 exec: None,
             },
@@ -420,6 +422,11 @@ impl SessionManager {
             if session.pyrunner_dirty {
                 restart_pyrunner(session);
                 session.pyrunner_dirty = false;
+            }
+
+            if !session.pyrunner_reseeded {
+                reseed_pyrunner(session);
+                session.pyrunner_reseeded = true;
             }
 
             let b64 = base64::engine::general_purpose::STANDARD.encode(code.as_bytes());
@@ -552,7 +559,7 @@ impl SessionManager {
             .map_err(|e| format!("suspend failed: {e}"))?;
 
         let meta = format!(
-            "{}|{}|{}",
+            "{}|{}|{}|{}",
             if session.is_shell {
                 "shell"
             } else if session.is_pyrunner {
@@ -561,6 +568,7 @@ impl SessionManager {
                 "custom"
             },
             session.has_pyrunner,
+            session.pyrunner_reseeded,
             String::from_utf8_lossy(&session.prompt),
         );
 
@@ -599,9 +607,9 @@ impl SessionManager {
         machine::snapshot::restore_delta(&mut bus, &mut hart, &mut cursor)
             .map_err(|e| format!("resume failed: {e}"))?;
 
-        let parts: Vec<&str> = meta_str.splitn(3, '|').collect();
-        let prompt_bytes: Vec<u8> = if parts.len() == 3 {
-            parts[2].as_bytes().to_vec()
+        let parts: Vec<&str> = meta_str.splitn(4, '|').collect();
+        let prompt_bytes: Vec<u8> = if parts.len() == 4 {
+            parts[3].as_bytes().to_vec()
         } else {
             b"# ".to_vec()
         };
@@ -611,14 +619,22 @@ impl SessionManager {
         bus.uart_ctrl.drain_tx();
         hart.is_waiting = false;
         repl::sync_clock(&mut bus, &mut hart, &prompt_bytes);
-        let (is_shell, is_pyrunner, has_pyrunner, mut prompt) = if parts.len() == 3 {
-            let kind = parts[0];
-            let has_py = parts[1] == "true";
-            let prompt = parts[2].as_bytes().to_vec();
-            (kind == "shell", kind == "pyrunner", has_py, prompt)
-        } else {
-            (true, false, false, b"# ".to_vec())
-        };
+        let (is_shell, is_pyrunner, has_pyrunner, pyrunner_reseeded, mut prompt) =
+            if parts.len() == 4 {
+                let kind = parts[0];
+                let has_py = parts[1] == "true";
+                let reseeded = parts[2] == "true";
+                let prompt = parts[3].as_bytes().to_vec();
+                (
+                    kind == "shell",
+                    kind == "pyrunner",
+                    has_py,
+                    reseeded,
+                    prompt,
+                )
+            } else {
+                (true, false, false, false, b"# ".to_vec())
+            };
 
         if is_shell {
             install_prompt_sentinel(&mut bus, &mut hart, &mut prompt);
@@ -638,6 +654,7 @@ impl SessionManager {
                 is_pyrunner,
                 has_pyrunner,
                 pyrunner_dirty: false,
+                pyrunner_reseeded,
                 shell_lost: false,
                 exec: None,
             },
@@ -645,6 +662,47 @@ impl SessionManager {
 
         Ok(id)
     }
+}
+
+const PYRUNNER_RESEED_CODE: &str = "import random\nrandom.seed()\ndel random";
+
+fn warn_if_pyrunner_unseeded(complaint: &[u8]) {
+    static WARNED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+    if complaint.is_empty() || WARNED.swap(true, std::sync::atomic::Ordering::Relaxed) {
+        return;
+    }
+
+    eprintln!(
+        "[vpod] warning: could not reseed the interpreter's random module, so every \
+         sandbox from this snapshot will get the same random.random() sequence. \
+         os.urandom, secrets and uuid4 are unaffected. ({})",
+        String::from_utf8_lossy(complaint).trim()
+    );
+}
+
+fn reseed_pyrunner(session: &mut Session) {
+    let line = base64::engine::general_purpose::STANDARD.encode(PYRUNNER_RESEED_CODE.as_bytes());
+
+    for byte in line.bytes() {
+        session.bus.uart_data.push_rx(byte);
+    }
+    session.bus.uart_data.push_rx(b'\n');
+
+    let _ = repl::capture_output(
+        &mut session.bus,
+        &mut session.hart,
+        b"",
+        30,
+        false,
+        Some(PYRUNNER_SENTINEL),
+        true,
+    );
+
+    repl::drain_ctrl_with_grace(&mut session.bus, &mut session.hart);
+    warn_if_pyrunner_unseeded(&session.bus.uart_stderr.drain_tx());
+
+    session.bus.uart_data.drain_tx();
 }
 
 fn restart_pyrunner(session: &mut Session) {
@@ -682,4 +740,6 @@ fn restart_pyrunner(session: &mut Session) {
     session.bus.uart_data.drain_tx();
     session.bus.uart_stderr.drain_tx();
     session.bus.uart_ctrl.drain_tx();
+
+    session.pyrunner_reseeded = true;
 }

--- a/crates/wasi-component/src/api/session.rs
+++ b/crates/wasi-component/src/api/session.rs
@@ -664,7 +664,13 @@ impl SessionManager {
     }
 }
 
-const PYRUNNER_RESEED_CODE: &str = "import random\nrandom.seed()\ndel random";
+const PYRUNNER_RESEED_CODE: &str = "\
+import sys, random
+random.seed()
+numpy = sys.modules.get('numpy')
+if numpy is not None:
+    numpy.random.seed()
+del sys, random, numpy";
 
 fn warn_if_pyrunner_unseeded(complaint: &[u8]) {
     static WARNED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);

--- a/crates/wasi-component/src/api/session.rs
+++ b/crates/wasi-component/src/api/session.rs
@@ -326,6 +326,8 @@ impl SessionManager {
 
             repl::shell_init(&mut bus, &mut hart, &prompt_bytes);
         } else {
+            repl::reseed(&mut bus, &mut hart, &prompt_bytes);
+
             let launch = format!("stty -echo; {command}\n");
             for byte in launch.bytes() {
                 bus.uart.push_rx(byte);

--- a/crates/wasi-component/src/repl.rs
+++ b/crates/wasi-component/src/repl.rs
@@ -12,9 +12,60 @@ const NET_YIELD_NS: u64 = 5_000_000; // 5 ms
 
 const GRACE_STEPS: u32 = 2000;
 
+const SEED_BINARY: &str = "/usr/lib/vpod/vpod-seed-entropy";
+const SEED_BYTES: u64 = 32;
+
+pub fn reseed_fragment() -> String {
+    let seed = wasi::random::random::get_random_bytes(SEED_BYTES);
+
+    let mut hex = String::with_capacity(seed.len() * 2);
+    for byte in &seed {
+        hex.push_str(&format!("{byte:02x}"));
+    }
+
+    format!("{SEED_BINARY} {hex}")
+}
+
+fn warn_if_unseeded(complaint: &[u8]) {
+    static WARNED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+    if complaint.is_empty() || WARNED.swap(true, std::sync::atomic::Ordering::Relaxed) {
+        return;
+    }
+
+    eprintln!(
+        "[vpod] warning: could not reseed the guest random pool, so every sandbox from \
+         this snapshot will produce identical random bytes. Re-pull the snapshot so it \
+         carries {SEED_BINARY}. ({})",
+        String::from_utf8_lossy(complaint).trim()
+    );
+}
+
+pub fn reseed(bus: &mut MachineBus, hart: &mut Hart, prompt: &[u8]) {
+    let cmd = format!("{} 2>/dev/ttyS1\n", reseed_fragment());
+
+    bus.uart_stderr.drain_tx();
+
+    for byte in cmd.bytes() {
+        bus.uart.push_rx(byte);
+    }
+
+    wait_for_prompt(bus, hart, prompt);
+
+    bus.uart.drain_tx();
+    warn_if_unseeded(&bus.uart_stderr.drain_tx());
+    bus.uart_ctrl.drain_tx();
+}
+
 pub fn sync_clock(bus: &mut MachineBus, hart: &mut Hart, prompt: &[u8]) {
     let now = wall_clock::now();
-    let date_cmd = format!("date -s @{}\n", now.seconds);
+    let date_cmd = format!(
+        "date -s @{} >/dev/null; {} 2>/dev/ttyS1\n",
+        now.seconds,
+        reseed_fragment()
+    );
+
+    bus.uart_stderr.drain_tx();
 
     for byte in date_cmd.bytes() {
         bus.uart.push_rx(byte);
@@ -23,7 +74,7 @@ pub fn sync_clock(bus: &mut MachineBus, hart: &mut Hart, prompt: &[u8]) {
     wait_for_prompt(bus, hart, prompt);
 
     bus.uart.drain_tx();
-    bus.uart_stderr.drain_tx();
+    warn_if_unseeded(&bus.uart_stderr.drain_tx());
     bus.uart_ctrl.drain_tx();
 }
 

--- a/crates/wasi-component/src/repl.rs
+++ b/crates/wasi-component/src/repl.rs
@@ -15,15 +15,16 @@ const GRACE_STEPS: u32 = 2000;
 const SEED_BINARY: &str = "/usr/lib/vpod/vpod-seed-entropy";
 const SEED_BYTES: u64 = 32;
 
-pub fn reseed_fragment() -> String {
+fn reseed_fragment() -> String {
     let seed = wasi::random::random::get_random_bytes(SEED_BYTES);
 
     let mut hex = String::with_capacity(seed.len() * 2);
     for byte in &seed {
         hex.push_str(&format!("{byte:02x}"));
     }
+    let shell_seed = wasi::random::random::get_random_u64() as u32;
 
-    format!("{SEED_BINARY} {hex}")
+    format!("RANDOM={shell_seed}; {SEED_BINARY} {hex} 2>/dev/ttyS1")
 }
 
 fn warn_if_unseeded(complaint: &[u8]) {
@@ -41,45 +42,48 @@ fn warn_if_unseeded(complaint: &[u8]) {
     );
 }
 
-pub fn reseed(bus: &mut MachineBus, hart: &mut Hart, prompt: &[u8]) {
-    let cmd = format!("{} 2>/dev/ttyS1\n", reseed_fragment());
-
+fn run_quietly(bus: &mut MachineBus, hart: &mut Hart, prompt: &[u8], cmd: &str) -> Vec<u8> {
     bus.uart_stderr.drain_tx();
 
     for byte in cmd.bytes() {
         bus.uart.push_rx(byte);
     }
+    bus.uart.push_rx(b'\n');
 
     wait_for_prompt(bus, hart, prompt);
 
     bus.uart.drain_tx();
-    warn_if_unseeded(&bus.uart_stderr.drain_tx());
+    let complaint = bus.uart_stderr.drain_tx();
     bus.uart_ctrl.drain_tx();
+
+    complaint
+}
+
+pub fn reseed(bus: &mut MachineBus, hart: &mut Hart, prompt: &[u8]) {
+    let complaint = run_quietly(bus, hart, prompt, &reseed_fragment());
+    warn_if_unseeded(&complaint);
 }
 
 pub fn sync_clock(bus: &mut MachineBus, hart: &mut Hart, prompt: &[u8]) {
     let now = wall_clock::now();
-    let date_cmd = format!(
-        "date -s @{} >/dev/null; {} 2>/dev/ttyS1\n",
-        now.seconds,
-        reseed_fragment()
+    run_quietly(
+        bus,
+        hart,
+        prompt,
+        &format!("date -s @{} >/dev/null", now.seconds),
     );
+}
 
-    bus.uart_stderr.drain_tx();
+pub fn sync_clock_and_reseed(bus: &mut MachineBus, hart: &mut Hart, prompt: &[u8]) {
+    let now = wall_clock::now();
+    let cmd = format!("date -s @{} >/dev/null; {}", now.seconds, reseed_fragment());
 
-    for byte in date_cmd.bytes() {
-        bus.uart.push_rx(byte);
-    }
-
-    wait_for_prompt(bus, hart, prompt);
-
-    bus.uart.drain_tx();
-    warn_if_unseeded(&bus.uart_stderr.drain_tx());
-    bus.uart_ctrl.drain_tx();
+    let complaint = run_quietly(bus, hart, prompt, &cmd);
+    warn_if_unseeded(&complaint);
 }
 
 pub fn shell_init(bus: &mut MachineBus, hart: &mut Hart, prompt: &[u8]) {
-    sync_clock(bus, hart, prompt);
+    sync_clock_and_reseed(bus, hart, prompt);
 
     for byte in b"stty -echo\n" {
         bus.uart.push_rx(*byte);

--- a/guest/entropy/vpod_seed_entropy.c
+++ b/guest/entropy/vpod_seed_entropy.c
@@ -1,0 +1,84 @@
+#include <fcntl.h>
+#include <linux/random.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#ifndef RNDRESEEDCRNG
+#define RNDRESEEDCRNG _IO('R', 0x07)
+#endif
+
+#define MAX_SEED_BYTES 512
+
+static int unhex(char digit) {
+    if (digit >= '0' && digit <= '9')
+        return digit - '0';
+
+    if (digit >= 'a' && digit <= 'f')
+        return digit - 'a' + 10;
+
+    if (digit >= 'A' && digit <= 'F')
+        return digit - 'A' + 10;
+
+    return -1;
+}
+
+int main(int argc, char **argv) {
+
+    struct {
+        struct rand_pool_info info;
+        unsigned char buf[MAX_SEED_BYTES];
+    } pool;
+
+    if (argc != 2) {
+        fprintf(stderr, "usage: vpod-seed-entropy <hex>\n");
+        return 1;
+    }
+
+    size_t digits = strlen(argv[1]);
+    if (digits == 0 || digits % 2 != 0 || digits / 2 > MAX_SEED_BYTES) {
+        fprintf(stderr, "vpod-seed-entropy: need an even count of at most %d hex digits, got %zu\n",
+                MAX_SEED_BYTES * 2, digits);
+
+        return 1;
+    }
+
+    size_t seed_bytes = digits / 2;
+    for (size_t i = 0; i < seed_bytes; i++) {
+        int high = unhex(argv[1][i * 2]);
+        int low = unhex(argv[1][i * 2 + 1]);
+
+        if (high < 0 || low < 0) {
+            fprintf(stderr, "vpod-seed-entropy: argument is not hex\n");
+            return 1;
+        }
+
+        pool.buf[i] = (unsigned char)((high << 4) | low);
+    }
+
+    int fd = open("/dev/urandom", O_WRONLY);
+
+    if (fd < 0) {
+        perror("vpod-seed-entropy: open /dev/urandom");
+        return 1;
+    }
+
+    pool.info.entropy_count = (int)(seed_bytes * 8);
+    pool.info.buf_size = (int)seed_bytes;
+
+    if (ioctl(fd, RNDADDENTROPY, &pool) != 0) {
+        perror("vpod-seed-entropy: RNDADDENTROPY");
+        close(fd);
+        return 1;
+    }
+
+    if (ioctl(fd, RNDRESEEDCRNG, 0) != 0) {
+        perror("vpod-seed-entropy: RNDRESEEDCRNG");
+        close(fd);
+        return 1;
+    }
+
+    close(fd);
+    return 0;
+}

--- a/scripts/build-data-snapshot.sh
+++ b/scripts/build-data-snapshot.sh
@@ -353,6 +353,7 @@ echo "── Booting guest to pre-install ca-certificates + python3 + data stack
 CA_MARKER="$(sed -n '2p' "$ROOT/crates/machine/assets/tls/vpod-ca-cert.pem")"
 BUILD_LOG="$ROOT/dist/.snapshot-build.log"
 NOW="$(date -u '+%Y-%m-%d %H:%M:%S')"
+SEED_HEX="$(od -An -tx1 -N32 /dev/urandom | tr -d ' \n')"
 
 
 SETUP_CMD=""
@@ -368,7 +369,7 @@ SETUP_CMD="${SETUP_CMD}grep -qF '$CA_MARKER' /etc/ssl/certs/ca-certificates.crt 
 SETUP_CMD="${SETUP_CMD}if grep -qF '$CA_MARKER' /etc/ssl/certs/ca-certificates.crt; then echo VPOD_CA_INSTALLED; else echo VPOD_CA_FAILED; fi; "
 SETUP_CMD="${SETUP_CMD}sed -i 's|http://|https://|g' /etc/apk/repositories; "
 SETUP_CMD="${SETUP_CMD}cp /usr/bin/ssl_client /usr/bin/ssl_client.real && cp /usr/lib/vpod/vpod-ssl-client /usr/bin/ssl_client && chmod +x /usr/bin/ssl_client && echo VPOD_SSL_CLIENT_SWAPPED; "
-SETUP_CMD="${SETUP_CMD}/usr/lib/vpod/vpod-seed-entropy 00112233445566778899aabbccddeeff && echo VPOD_SEED_ENTROPY_OK; "
+SETUP_CMD="${SETUP_CMD}/usr/lib/vpod/vpod-seed-entropy $SEED_HEX && echo VPOD_SEED_ENTROPY_OK; "
 SETUP_CMD="${SETUP_CMD}PYBIN=\$(readlink -f /usr/bin/python3) && cp \$PYBIN /usr/bin/python3.real && cp /usr/lib/vpod/vpod-python-shim \$PYBIN && chmod +x \$PYBIN /usr/bin/python3.real && echo VPOD_PY_SHIM_INSTALLED; "
 SETUP_CMD="${SETUP_CMD}/usr/bin/python3.real /usr/lib/vpod/pydaemon.py </dev/null >/dev/null 2>&1 & "
 SETUP_CMD="${SETUP_CMD}n=0; while [ ! -S /run/vpod-pyd.sock ] && [ \$n -lt 300 ]; do sleep 0.1; n=\$((n+1)); done; "

--- a/scripts/build-data-snapshot.sh
+++ b/scripts/build-data-snapshot.sh
@@ -136,6 +136,12 @@ zig cc -target riscv64-linux-musl -Os -static -s \
     "$ROOT/guest/tls/vpod_ssl_client.c"
 chmod +x "$OVERLAY/usr/lib/vpod/vpod-ssl-client"
 
+echo "── Cross-compiling vpod seed_entropy (riscv64-musl, static)..."
+zig cc -target riscv64-linux-musl -Os -static -s \
+    -o "$OVERLAY/usr/lib/vpod/vpod-seed-entropy" \
+    "$ROOT/guest/entropy/vpod_seed_entropy.c"
+chmod +x "$OVERLAY/usr/lib/vpod/vpod-seed-entropy"
+
 mkdir -p "$OVERLAY/etc/vpod"
 cat > "$OVERLAY/etc/vpod/pydaemon-warm-imports" << 'WARM_EOF'
 #Warm set for the python3 shim/daemon path (commands.run("python3 ...")
@@ -362,6 +368,7 @@ SETUP_CMD="${SETUP_CMD}grep -qF '$CA_MARKER' /etc/ssl/certs/ca-certificates.crt 
 SETUP_CMD="${SETUP_CMD}if grep -qF '$CA_MARKER' /etc/ssl/certs/ca-certificates.crt; then echo VPOD_CA_INSTALLED; else echo VPOD_CA_FAILED; fi; "
 SETUP_CMD="${SETUP_CMD}sed -i 's|http://|https://|g' /etc/apk/repositories; "
 SETUP_CMD="${SETUP_CMD}cp /usr/bin/ssl_client /usr/bin/ssl_client.real && cp /usr/lib/vpod/vpod-ssl-client /usr/bin/ssl_client && chmod +x /usr/bin/ssl_client && echo VPOD_SSL_CLIENT_SWAPPED; "
+SETUP_CMD="${SETUP_CMD}/usr/lib/vpod/vpod-seed-entropy 00112233445566778899aabbccddeeff && echo VPOD_SEED_ENTROPY_OK; "
 SETUP_CMD="${SETUP_CMD}PYBIN=\$(readlink -f /usr/bin/python3) && cp \$PYBIN /usr/bin/python3.real && cp /usr/lib/vpod/vpod-python-shim \$PYBIN && chmod +x \$PYBIN /usr/bin/python3.real && echo VPOD_PY_SHIM_INSTALLED; "
 SETUP_CMD="${SETUP_CMD}/usr/bin/python3.real /usr/lib/vpod/pydaemon.py </dev/null >/dev/null 2>&1 & "
 SETUP_CMD="${SETUP_CMD}n=0; while [ ! -S /run/vpod-pyd.sock ] && [ \$n -lt 300 ]; do sleep 0.1; n=\$((n+1)); done; "
@@ -391,6 +398,14 @@ if ! grep -q VPOD_SSL_CLIENT_SWAPPED "$BUILD_LOG"; then
     echo "" >&2
     echo "error: the vpod ssl_client was not installed over busybox's." >&2
     echo "       wget https would pay the full guest-TLS cost. Aborting the build." >&2
+    echo "       (see $BUILD_LOG for the guest setup output)" >&2
+    exit 1
+fi
+if ! grep -q VPOD_SEED_ENTROPY_OK "$BUILD_LOG"; then
+    echo "" >&2
+    echo "error: the guest could not reseed its random pool." >&2
+    echo "       Every sandbox resumed from this snapshot would share one crng key," >&2
+    echo "       so the same uuids, tokens and keys for every user. Aborting the build." >&2
     echo "       (see $BUILD_LOG for the guest setup output)" >&2
     exit 1
 fi

--- a/scripts/build-default-snapshot.sh
+++ b/scripts/build-default-snapshot.sh
@@ -136,6 +136,12 @@ zig cc -target riscv64-linux-musl -Os -static -s \
     "$ROOT/guest/tls/vpod_ssl_client.c"
 chmod +x "$OVERLAY/usr/lib/vpod/vpod-ssl-client"
 
+echo "── Cross-compiling vpod seed_entropy (riscv64-musl, static)..."
+zig cc -target riscv64-linux-musl -Os -static -s \
+    -o "$OVERLAY/usr/lib/vpod/vpod-seed-entropy" \
+    "$ROOT/guest/entropy/vpod_seed_entropy.c"
+chmod +x "$OVERLAY/usr/lib/vpod/vpod-seed-entropy"
+
 mkdir -p "$OVERLAY/etc/vpod"
 cat > "$OVERLAY/etc/vpod/pydaemon-warm-imports" << 'WARM_EOF'
 # Warm set for the python3 shim/daemon path (commands.run("python3 ...")
@@ -350,6 +356,7 @@ SETUP_CMD="${SETUP_CMD}grep -qF '$CA_MARKER' /etc/ssl/certs/ca-certificates.crt 
 SETUP_CMD="${SETUP_CMD}if grep -qF '$CA_MARKER' /etc/ssl/certs/ca-certificates.crt; then echo VPOD_CA_INSTALLED; else echo VPOD_CA_FAILED; fi; "
 SETUP_CMD="${SETUP_CMD}sed -i 's|http://|https://|g' /etc/apk/repositories; "
 SETUP_CMD="${SETUP_CMD}cp /usr/bin/ssl_client /usr/bin/ssl_client.real && cp /usr/lib/vpod/vpod-ssl-client /usr/bin/ssl_client && chmod +x /usr/bin/ssl_client && echo VPOD_SSL_CLIENT_SWAPPED; "
+SETUP_CMD="${SETUP_CMD}/usr/lib/vpod/vpod-seed-entropy 00112233445566778899aabbccddeeff && echo VPOD_SEED_ENTROPY_OK; "
 SETUP_CMD="${SETUP_CMD}PYBIN=\$(readlink -f /usr/bin/python3) && cp \$PYBIN /usr/bin/python3.real && cp /usr/lib/vpod/vpod-python-shim \$PYBIN && chmod +x \$PYBIN /usr/bin/python3.real && echo VPOD_PY_SHIM_INSTALLED; "
 SETUP_CMD="${SETUP_CMD}/usr/bin/python3.real /usr/lib/vpod/pydaemon.py </dev/null >/dev/null 2>&1 & "
 SETUP_CMD="${SETUP_CMD}n=0; while [ ! -S /run/vpod-pyd.sock ] && [ \$n -lt 300 ]; do sleep 0.1; n=\$((n+1)); done; "
@@ -379,6 +386,14 @@ if ! grep -q VPOD_SSL_CLIENT_SWAPPED "$BUILD_LOG"; then
     echo "" >&2
     echo "error: the vpod ssl_client was not installed over busybox's." >&2
     echo "       wget https would pay the full guest-TLS cost. Aborting the build." >&2
+    echo "       (see $BUILD_LOG for the guest setup output)" >&2
+    exit 1
+fi
+if ! grep -q VPOD_SEED_ENTROPY_OK "$BUILD_LOG"; then
+    echo "" >&2
+    echo "error: the guest could not reseed its random pool." >&2
+    echo "       Every sandbox resumed from this snapshot would share one crng key," >&2
+    echo "       so the same uuids, tokens and keys for every user. Aborting the build." >&2
     echo "       (see $BUILD_LOG for the guest setup output)" >&2
     exit 1
 fi

--- a/scripts/build-default-snapshot.sh
+++ b/scripts/build-default-snapshot.sh
@@ -341,6 +341,7 @@ echo "── Booting guest to pre-install ca-certificates + python3..."
 CA_MARKER="$(sed -n '2p' "$ROOT/crates/machine/assets/tls/vpod-ca-cert.pem")"
 BUILD_LOG="$ROOT/dist/.snapshot-build.log"
 NOW="$(date -u '+%Y-%m-%d %H:%M:%S')"
+SEED_HEX="$(od -An -tx1 -N32 /dev/urandom | tr -d ' \n')"
 
 
 SETUP_CMD=""
@@ -356,7 +357,7 @@ SETUP_CMD="${SETUP_CMD}grep -qF '$CA_MARKER' /etc/ssl/certs/ca-certificates.crt 
 SETUP_CMD="${SETUP_CMD}if grep -qF '$CA_MARKER' /etc/ssl/certs/ca-certificates.crt; then echo VPOD_CA_INSTALLED; else echo VPOD_CA_FAILED; fi; "
 SETUP_CMD="${SETUP_CMD}sed -i 's|http://|https://|g' /etc/apk/repositories; "
 SETUP_CMD="${SETUP_CMD}cp /usr/bin/ssl_client /usr/bin/ssl_client.real && cp /usr/lib/vpod/vpod-ssl-client /usr/bin/ssl_client && chmod +x /usr/bin/ssl_client && echo VPOD_SSL_CLIENT_SWAPPED; "
-SETUP_CMD="${SETUP_CMD}/usr/lib/vpod/vpod-seed-entropy 00112233445566778899aabbccddeeff && echo VPOD_SEED_ENTROPY_OK; "
+SETUP_CMD="${SETUP_CMD}/usr/lib/vpod/vpod-seed-entropy $SEED_HEX && echo VPOD_SEED_ENTROPY_OK; "
 SETUP_CMD="${SETUP_CMD}PYBIN=\$(readlink -f /usr/bin/python3) && cp \$PYBIN /usr/bin/python3.real && cp /usr/lib/vpod/vpod-python-shim \$PYBIN && chmod +x \$PYBIN /usr/bin/python3.real && echo VPOD_PY_SHIM_INSTALLED; "
 SETUP_CMD="${SETUP_CMD}/usr/bin/python3.real /usr/lib/vpod/pydaemon.py </dev/null >/dev/null 2>&1 & "
 SETUP_CMD="${SETUP_CMD}n=0; while [ ! -S /run/vpod-pyd.sock ] && [ \$n -lt 300 ]; do sleep 0.1; n=\$((n+1)); done; "

--- a/sdks/python/tests/test_integration.py
+++ b/sdks/python/tests/test_integration.py
@@ -717,6 +717,34 @@ def test_two_sandboxes_do_not_share_one_mersenne_twister():
     )
 
 
+def test_two_sandboxes_do_not_share_one_numpy_global():
+    probe = (
+        "try:\n"
+        "    import numpy\n"
+        "except ImportError:\n"
+        "    print('NO_NUMPY')\n"
+        "else:\n"
+        "    print(numpy.random.rand(), numpy.random.randint(0, 10**9))"
+    )
+
+    samples = []
+    for _ in range(2):
+        with Sandbox.create() as sbx:
+            result = sbx.code.run(probe, timeout=180)
+            assert result.success, f"the probe failed: {result.error}"
+            samples.append(result.text.strip())
+
+    first, second = samples
+    if first == "NO_NUMPY":
+        pytest.skip("this snapshot does not carry numpy")
+
+    assert first != second, (
+        f"both sandboxes produced {first!r}. numpy.random's legacy global was seeded "
+        f"when the snapshot warm-imported it, so reseeding the kernel pool and random "
+        f"alone leaves it shared."
+    )
+
+
 def test_two_shells_do_not_share_one_random_variable():
     samples = []
     for _ in range(2):

--- a/sdks/python/tests/test_integration.py
+++ b/sdks/python/tests/test_integration.py
@@ -701,6 +701,55 @@ def test_the_shell_gets_the_same_reseed_as_the_interpreter():
     assert first and second, "the read returned nothing"
     assert first != second, f"both shells read {first!r} from /dev/urandom"
 
+def test_two_sandboxes_do_not_share_one_mersenne_twister():
+    samples = []
+    for _ in range(2):
+        with Sandbox.create() as sbx:
+            result = sbx.code.run("import random\nprint(random.random())", timeout=120)
+            assert result.success, f"the probe failed: {result.error}"
+            samples.append(result.text.strip())
+
+    first, second = samples
+    assert first and second, "the probe printed nothing"
+    assert first != second, (
+        f"both sandboxes produced {first!r}. The interpreter was restored with random "
+        f"already imported, so its Mersenne Twister state came from the snapshot."
+    )
+
+
+def test_two_shells_do_not_share_one_random_variable():
+    samples = []
+    for _ in range(2):
+        with Sandbox.create() as sbx:
+            result = sbx.commands.run("echo $RANDOM $RANDOM $RANDOM", timeout=60)
+            assert result.exit_code == 0, result.stderr
+            samples.append(result.stdout.strip())
+
+    first, second = samples
+    assert first and second, "the shell printed nothing"
+    assert first != second, (
+        f"both shells produced {first!r}. RANDOM is the shell's own generator, seeded "
+        f"before the snapshot was taken, so it survives a kernel pool reseed."
+    )
+
+
+def test_a_seed_the_caller_sets_on_purpose_survives():
+    with Sandbox.create() as sbx:
+        seeded = sbx.code.run("import random\nrandom.seed(42)", timeout=120)
+        assert seeded.success, f"seeding failed: {seeded.error}"
+
+        first = sbx.code.run("print(random.random())", timeout=120)
+        assert first.success, f"the probe failed: {first.error}"
+
+        reference = sbx.code.run(
+            "import random\nrandom.seed(42)\nprint(random.random())", timeout=120
+        )
+
+        assert first.text.strip() == reference.text.strip(), (
+            "a reseed ran between two calls in one sandbox and threw away the caller's "
+            "own random.seed(42)"
+        )
+
 
 def test_an_unfinishable_command_waits_for_its_timeout_rather_than_guessing():
     with Sandbox.create() as sbx:

--- a/sdks/python/tests/test_integration.py
+++ b/sdks/python/tests/test_integration.py
@@ -667,6 +667,41 @@ def test_a_command_that_cannot_finish_can_be_interrupted():
         assert sbx.commands.run("echo alive").stdout.strip() == "alive"
 
 
+def test_two_sandboxes_do_not_share_one_random_stream():
+    probe = (
+        "import os, secrets, uuid\n"
+        "print(os.urandom(16).hex(), secrets.token_hex(16), uuid.uuid4())"
+    )
+
+    samples = []
+    for _ in range(2):
+        with Sandbox.create() as sbx:
+            result = sbx.code.run(probe, timeout=120)
+            assert result.success, f"the probe failed: {result.error}"
+            samples.append(result.text.strip())
+
+    first, second = samples
+    assert first and second, "the probe printed nothing"
+    assert first != second, (
+        f"both sandboxes produced {first!r}. The guest crng was restored from the "
+        f"snapshot and never re-keyed, so every sandbox from this image shares one "
+        f"stream of uuids, tokens and keys."
+    )
+
+
+def test_the_shell_gets_the_same_reseed_as_the_interpreter():
+    samples = []
+    for _ in range(2):
+        with Sandbox.create() as sbx:
+            result = sbx.commands.run("head -c 16 /dev/urandom | od -An -tx1", timeout=60)
+            assert result.exit_code == 0, result.stderr
+            samples.append(result.stdout.strip())
+
+    first, second = samples
+    assert first and second, "the read returned nothing"
+    assert first != second, f"both shells read {first!r} from /dev/urandom"
+
+
 def test_an_unfinishable_command_waits_for_its_timeout_rather_than_guessing():
     with Sandbox.create() as sbx:
         started = time.time()

--- a/sdks/typescript/tests/integration/entropy.test.mjs
+++ b/sdks/typescript/tests/integration/entropy.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { skipReason, withSandbox } from "../helpers.mjs";
+
+describe("entropy", { skip: skipReason() ?? false }, () => {
+    it("does not hand two sandboxes the same random stream", async () => {
+        const probe =
+            "import os, secrets, uuid\n" +
+            "print(os.urandom(16).hex(), secrets.token_hex(16), uuid.uuid4())";
+
+        const samples = [];
+        for (let round = 0; round < 2; round += 1) {
+            await withSandbox(async (sandbox) => {
+                const result = await sandbox.code.run(probe);
+                assert.equal(result.success, true, `the probe failed: ${result.error}`);
+                samples.push(result.text.trim());
+            });
+        }
+
+        const [first, second] = samples;
+        assert.ok(first, "the probe printed nothing");
+        assert.notEqual(
+            first,
+            second,
+            `both sandboxes produced ${first}. The guest crng was restored from the ` +
+                `snapshot and never re-keyed, so every sandbox from this image shares ` +
+                `one stream of uuids, tokens and keys.`,
+        );
+    });
+
+    it("reseeds the shell as well as the interpreter", async () => {
+        const samples = [];
+        for (let round = 0; round < 2; round += 1) {
+            await withSandbox(async (sandbox) => {
+                const result = await sandbox.commands.run(
+                    "head -c 16 /dev/urandom | od -An -tx1",
+                );
+                assert.equal(result.exitCode, 0, result.stderr);
+                samples.push(result.stdout.trim());
+            });
+        }
+
+        const [first, second] = samples;
+        assert.ok(first, "the read returned nothing");
+        assert.notEqual(first, second, `both shells read ${first} from /dev/urandom`);
+    });
+});

--- a/sdks/typescript/tests/integration/entropy.test.mjs
+++ b/sdks/typescript/tests/integration/entropy.test.mjs
@@ -62,6 +62,35 @@ describe("entropy", { skip: skipReason() ?? false }, () => {
         );
     });
 
+    it("does not hand two sandboxes the same numpy global stream", async (t) => {
+        const probe =
+            "try:\n" +
+            "    import numpy\n" +
+            "except ImportError:\n" +
+            "    print('NO_NUMPY')\n" +
+            "else:\n" +
+            "    print(numpy.random.rand(), numpy.random.randint(0, 10**9))";
+
+        const [first, second] = await sampleTwice(async (sandbox) => {
+            const result = await sandbox.code.run(probe, { timeout: 180 });
+            assert.equal(result.success, true, `the probe failed: ${result.error}`);
+            return result.text.trim();
+        });
+
+        if (first === "NO_NUMPY") {
+            t.skip("this snapshot does not carry numpy");
+            return;
+        }
+
+        assert.notEqual(
+            first,
+            second,
+            `both sandboxes produced ${first}. numpy.random's legacy global was seeded ` +
+                `when the snapshot warm-imported it, so reseeding the kernel pool and ` +
+                `random alone leaves it shared.`,
+        );
+    });
+
     it("does not hand two shells the same $RANDOM sequence", async () => {
         const [first, second] = await sampleTwice(async (sandbox) => {
             const result = await sandbox.commands.run("echo $RANDOM $RANDOM $RANDOM");

--- a/sdks/typescript/tests/integration/entropy.test.mjs
+++ b/sdks/typescript/tests/integration/entropy.test.mjs
@@ -3,22 +3,28 @@ import { describe, it } from "node:test";
 
 import { skipReason, withSandbox } from "../helpers.mjs";
 
+async function sampleTwice(take) {
+    const samples = [];
+    for (let round = 0; round < 2; round += 1) {
+        await withSandbox(async (sandbox) => {
+            samples.push(await take(sandbox));
+        });
+    }
+    return samples;
+}
+
 describe("entropy", { skip: skipReason() ?? false }, () => {
     it("does not hand two sandboxes the same random stream", async () => {
         const probe =
             "import os, secrets, uuid\n" +
             "print(os.urandom(16).hex(), secrets.token_hex(16), uuid.uuid4())";
 
-        const samples = [];
-        for (let round = 0; round < 2; round += 1) {
-            await withSandbox(async (sandbox) => {
-                const result = await sandbox.code.run(probe);
-                assert.equal(result.success, true, `the probe failed: ${result.error}`);
-                samples.push(result.text.trim());
-            });
-        }
+        const [first, second] = await sampleTwice(async (sandbox) => {
+            const result = await sandbox.code.run(probe);
+            assert.equal(result.success, true, `the probe failed: ${result.error}`);
+            return result.text.trim();
+        });
 
-        const [first, second] = samples;
         assert.ok(first, "the probe printed nothing");
         assert.notEqual(
             first,
@@ -30,19 +36,66 @@ describe("entropy", { skip: skipReason() ?? false }, () => {
     });
 
     it("reseeds the shell as well as the interpreter", async () => {
-        const samples = [];
-        for (let round = 0; round < 2; round += 1) {
-            await withSandbox(async (sandbox) => {
-                const result = await sandbox.commands.run(
-                    "head -c 16 /dev/urandom | od -An -tx1",
-                );
-                assert.equal(result.exitCode, 0, result.stderr);
-                samples.push(result.stdout.trim());
-            });
-        }
+        const [first, second] = await sampleTwice(async (sandbox) => {
+            const result = await sandbox.commands.run("head -c 16 /dev/urandom | od -An -tx1");
+            assert.equal(result.exitCode, 0, result.stderr);
+            return result.stdout.trim();
+        });
 
-        const [first, second] = samples;
         assert.ok(first, "the read returned nothing");
         assert.notEqual(first, second, `both shells read ${first} from /dev/urandom`);
+    });
+
+    it("does not hand two sandboxes the same random.random() sequence", async () => {
+        const [first, second] = await sampleTwice(async (sandbox) => {
+            const result = await sandbox.code.run("import random\nprint(random.random())");
+            assert.equal(result.success, true, `the probe failed: ${result.error}`);
+            return result.text.trim();
+        });
+
+        assert.ok(first, "the probe printed nothing");
+        assert.notEqual(
+            first,
+            second,
+            `both sandboxes produced ${first}. The interpreter was restored with random ` +
+                `already imported, so its Mersenne Twister state came from the snapshot.`,
+        );
+    });
+
+    it("does not hand two shells the same $RANDOM sequence", async () => {
+        const [first, second] = await sampleTwice(async (sandbox) => {
+            const result = await sandbox.commands.run("echo $RANDOM $RANDOM $RANDOM");
+            assert.equal(result.exitCode, 0, result.stderr);
+            return result.stdout.trim();
+        });
+
+        assert.ok(first, "the shell printed nothing");
+        assert.notEqual(
+            first,
+            second,
+            `both shells produced ${first}. RANDOM is the shell's own generator, seeded ` +
+                `before the snapshot was taken, so it survives a kernel pool reseed.`,
+        );
+    });
+
+    it("leaves a seed the caller sets on purpose alone", async () => {
+        await withSandbox(async (sandbox) => {
+            const seeded = await sandbox.code.run("import random\nrandom.seed(42)");
+            assert.equal(seeded.success, true, `seeding failed: ${seeded.error}`);
+
+            const first = await sandbox.code.run("print(random.random())");
+            assert.equal(first.success, true, `the probe failed: ${first.error}`);
+
+            const reference = await sandbox.code.run(
+                "import random\nrandom.seed(42)\nprint(random.random())",
+            );
+
+            assert.equal(
+                first.text.trim(),
+                reference.text.trim(),
+                "a reseed ran between two calls in one sandbox and threw away the " +
+                    "caller's own random.seed(42)",
+            );
+        });
     });
 });


### PR DESCRIPTION
Vpod sandboxes returned the same random bytes, same uuid4 etc.. every time. 

The `crng` is captured already initialized, and `credit_init_bits()` returns early once `crng_ready()` is true, so `RNDADDENTROPY` alone is a no-op on a restore. `RNDRESEEDCRNG` is what re-keys it. This runs both, at resume, with fresh host bytes on the line that already syncs the clock.

 Seeder from #79 => This adds the second ioctl and moves it from build time to resume time.