### PR TITLE
Limit wasmtime package version to <48.0.0

### DIFF
--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Topic :: System :: Emulators",
 ]
 dependencies = [
-    "wasmtime>=25.0.0",
+    "wasmtime>=25.0.0,<48",
     "platformdirs>=4.0",
     "certifi>=2023.0.0",
     "lz4>=4.4.5",

--- a/sdks/python/tests/test_integration.py
+++ b/sdks/python/tests/test_integration.py
@@ -1,3 +1,4 @@
+import socket
 import threading
 import time
 
@@ -364,19 +365,65 @@ def test_shell_working_directory():
         assert result.success
         assert "created_here.txt" in result.stdout
 
+NETWORK_HOST = "kfuckkfmkyxe0l-tests.vpod.sh"
+NETWORK_TIMEOUT = 15
+NETWORK_ATTEMPTS = 2
+
+
+def _wget(sbx, url, extra="", spider=True):
+    mode = "--spider" if spider else "-O-"
+    for attempt in range(NETWORK_ATTEMPTS):
+        result = sbx.commands.run(
+            f"wget -q {mode} -T {NETWORK_TIMEOUT} -t 1 {extra} {url}",
+            timeout=NETWORK_TIMEOUT * 2,
+        )
+        if result.success or attempt == NETWORK_ATTEMPTS - 1:
+            return result
+        time.sleep(1)
+    raise AssertionError("unreachable")
+
+
+def _which_layer_failed(sbx):
+    try:
+        address = socket.gethostbyname(NETWORK_HOST)
+    except OSError as unresolvable:
+        return (
+            f"the TEST RUNNER itself cannot resolve {NETWORK_HOST} ({unresolvable}), "
+            "so this says nothing about the guest"
+        )
+
+
+    by_name_http = _wget(sbx, f"http://{NETWORK_HOST}")
+    by_address = _wget(sbx, f"http://{address}", extra=f"--header 'Host: {NETWORK_HOST}'")
+
+    resolv = sbx.commands.run("cat /etc/resolv.conf").stdout.strip().replace("\n", " ")
+    link = sbx.commands.run("ip addr show eth0 2>&1 | head -1").stdout.strip()
+    where = f"resolv.conf={resolv!r} eth0={link!r}"
+
+    if by_name_http.success:
+        return f"DNS and egress are both fine over http, so this is TLS or https-specific. {where}"
+    if by_address.success:
+        return (
+            f"GUEST DNS is broken: {address} answers with a Host header, but the "
+            f"name does not resolve. {where}"
+        )
+    return f"GUEST EGRESS is broken: {address} is unreachable even without DNS. {where}"
+
+
 def test_network_dns_resolves():
     with Sandbox.create() as sbx:
-        result = sbx.commands.run(
-            "wget -q --spider -T 15 -t 1 https://kfuckkfmkyxe0l-tests.vpod.sh"
+        result = _wget(sbx, f"https://{NETWORK_HOST}")
+        assert result.success, (
+            f"exit={result.exit_code} stderr={result.stderr} :: {_which_layer_failed(sbx)}"
         )
-        assert result.success, f"exit={result.exit_code} stderr={result.stderr}"
+
 
 def test_network_https_fetches_body():
     with Sandbox.create() as sbx:
-        result = sbx.commands.run(
-            "wget -qO- -T 15 -t 1 https://kfuckkfmkyxe0l-tests.vpod.sh"
+        result = _wget(sbx, f"https://{NETWORK_HOST}", spider=False)
+        assert result.success, (
+            f"exit={result.exit_code} stderr={result.stderr} :: {_which_layer_failed(sbx)}"
         )
-        assert result.success, f"exit={result.exit_code} stderr={result.stderr}"
         assert "VPOD_TEST_OK" in result.stdout, f"stdout={result.stdout!r}"
 
 def test_shared_vm_shell_writes_python_reads():

--- a/sdks/python/tests/test_integration.py
+++ b/sdks/python/tests/test_integration.py
@@ -407,7 +407,27 @@ def _which_layer_failed(sbx):
             f"GUEST DNS is broken: {address} answers with a Host header, but the "
             f"name does not resolve. {where}"
         )
-    return f"GUEST EGRESS is broken: {address} is unreachable even without DNS. {where}"
+
+    # The guest cannot get out. Whether that is our problem depends entirely on
+    # whether the machine running these tests can, so ask it the same question.
+    # Without this the message cannot tell "vpod broke" from "this network
+    # cannot reach the host", and those need completely different people.
+    host_reachable = _host_can_reach(address, 80)
+    blame = (
+        "the RUNNER reaches it fine, so this is vpod's TCP path"
+        if host_reachable
+        else "the RUNNER cannot reach it either, so this is the network, not vpod"
+    )
+    return f"GUEST EGRESS is broken: {address}:80 unreachable without DNS. {blame}. {where}"
+
+
+def _host_can_reach(address, port, timeout=10):
+    """Can the machine running the tests open a TCP connection to the same place?"""
+    try:
+        with socket.create_connection((address, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
 
 
 def test_network_dns_resolves():

--- a/sdks/typescript/tests/integration/guest-egress.test.mjs
+++ b/sdks/typescript/tests/integration/guest-egress.test.mjs
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import { lookup } from "node:dns/promises";
+import { mkdtempSync, rmSync } from "node:fs";
+import { connect } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { after, before, describe, it } from "node:test";
+
+import { distPath, locateSnapshot, skipReason } from "../helpers.mjs";
+
+const reason = skipReason();
+
+const HOST = "kfuckkfmkyxe0l-tests.vpod.sh";
+const TIMEOUT_SECONDS = 15;
+
+function hostCanReach(address, port, milliseconds = 10_000) {
+    return new Promise((resolve) => {
+        const socket = connect({ host: address, port });
+        const settle = (reachable) => {
+            socket.destroy();
+            resolve(reachable);
+        };
+        socket.setTimeout(milliseconds, () => settle(false));
+        socket.once("connect", () => settle(true));
+        socket.once("error", () => settle(false));
+    });
+}
+
+describe("guest egress", { skip: reason ?? false }, () => {
+    let sandbox;
+    let cacheDirectory;
+    let address = null;
+
+    before(async () => {
+        cacheDirectory = mkdtempSync(join(tmpdir(), "vpod-cache-"));
+
+        const { Sandbox, createNodeTransport } = await import(distPath("node/index.js"));
+        sandbox = await Sandbox.create({
+            transport: await createNodeTransport({ cacheDirectory }),
+            snapshot: { path: locateSnapshot() },
+            network: true,
+        });
+        await sandbox.commands.run("echo warmup");
+
+        try {
+            address = (await lookup(HOST, { family: 4 })).address;
+        } catch {
+            address = null;
+        }
+    });
+
+    after(async () => {
+        await sandbox?.close();
+        if (cacheDirectory !== undefined) {
+            rmSync(cacheDirectory, { recursive: true, force: true });
+        }
+    });
+
+    const wget = (url, extra = "") =>
+        sandbox.commands.run(
+            `wget -q -O /dev/null -T ${TIMEOUT_SECONDS} -t 1 ${extra} ${url}`,
+            { timeout: TIMEOUT_SECONDS * 2 },
+        );
+
+    it("opens a TCP connection out of the guest at all", async (t) => {
+        if (address === null) {
+            t.skip("the test runner cannot resolve the host, so this proves nothing");
+            return;
+        }
+        if (!(await hostCanReach(address, 80))) {
+            t.skip("the test runner cannot reach the host either, so this is the network");
+            return;
+        }
+
+        const result = await wget(`http://${address}`, `--header 'Host: ${HOST}'`);
+
+        assert.equal(
+            result.exitCode,
+            0,
+            `guest cannot reach ${address}:80 without DNS, but this machine can. ` +
+                `That is vpod's socket path, not the network. stderr=${result.stderr}`,
+        );
+    });
+
+    it("resolves a name from inside the guest", async (t) => {
+        if (address === null) {
+            t.skip("the test runner cannot resolve the host, so this proves nothing");
+            return;
+        }
+
+        const byName = await wget(`http://${HOST}`);
+        if (byName.exitCode === 0) return;
+
+        const byAddress = await wget(`http://${address}`, `--header 'Host: ${HOST}'`);
+        assert.fail(
+            byAddress.exitCode === 0
+                ? `guest DNS is broken: ${address} answers with a Host header but the name does not resolve`
+                : `guest egress is broken: ${address} is unreachable even without DNS`,
+        );
+    });
+
+    it("completes a TLS handshake through the proxy", async (t) => {
+        if (address === null) {
+            t.skip("the test runner cannot resolve the host, so this proves nothing");
+            return;
+        }
+
+        const overTls = await sandbox.commands.run(
+            `wget -q -O- -T ${TIMEOUT_SECONDS} -t 1 https://${HOST}`,
+            { timeout: TIMEOUT_SECONDS * 2 },
+        );
+
+        if (overTls.exitCode !== 0) {
+            const plain = await wget(`http://${HOST}`);
+            assert.fail(
+                plain.exitCode === 0
+                    ? `http works but https does not, so this is the TLS proxy. stderr=${overTls.stderr}`
+                    : `neither http nor https works, so this is not TLS. stderr=${overTls.stderr}`,
+            );
+        }
+
+        assert.match(overTls.stdout, /VPOD_TEST_OK/);
+    });
+});


### PR DESCRIPTION
### EDIT
Github ci use the last version of wasmtime(48.0). Historically the wasmtime-wasi crate has allowed creation of TCP/UDP sockets by default but this changed with the last version.

https://github.com/bytecodealliance/wasmtime/releases/tag/v48.0.0



